### PR TITLE
[HOTFIX] Corrige partition_date_only nos flows de captura da transacao_ordem e lancamento

### DIFF
--- a/pipelines/capture__jae_lancamento/constants.py
+++ b/pipelines/capture__jae_lancamento/constants.py
@@ -17,5 +17,4 @@ LANCAMENTO_SOURCE = SourceTable(
     flow_folder_name="capture__jae_lancamento",
     primary_keys=["id_lancamento"],
     bucket_names=jae_constants.JAE_PRIVATE_BUCKET_NAMES,
-    partition_date_only=True,
 )

--- a/pipelines/capture__jae_transacao_ordem/constants.py
+++ b/pipelines/capture__jae_transacao_ordem/constants.py
@@ -17,4 +17,5 @@ JAE_TRANSACAO_ORDEM_SOURCE = SourceTable(
     flow_folder_name="capture__jae_transacao_ordem",
     primary_keys=["id", "id_ordem_ressarcimento", "data_processamento", "data_transacao"],
     max_recaptures=5,
+    partition_date_only=True,
 )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated data partitioning configuration for source data handling, adjusting how date-based partitioning is applied across data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->