### PR TITLE
Migra flow de verificação da captura dos dados da Jaé

### DIFF
--- a/pipelines/capture__jae_backup_billingpay/CHANGELOG.md
+++ b/pipelines/capture__jae_backup_billingpay/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog capture__jae_backup_billingpay
 
+## [1.1.1] - 2026-03-17
+
+### Adicionado
+
+- Altera lógica da timestamp do arquivo quando o parâmetro `end_datetime` é utilizado
+
 ## [1.1.0] - 2026-03-13
 
 ### Adicionado

--- a/pipelines/capture__jae_backup_billingpay/flow.py
+++ b/pipelines/capture__jae_backup_billingpay/flow.py
@@ -47,7 +47,8 @@ def capture__jae_backup_billingpay(
     setup_env = setup_environment(env=env)
 
     database_config = get_jae_db_config(database_name=database_name, wait_for=[sentry])
-    timestamp = get_scheduled_timestamp(timestamp=end_datetime, wait_for=[sentry])
+    end_timestamp = get_scheduled_timestamp(timestamp=end_datetime, wait_for=[sentry])
+    timestamp = get_scheduled_timestamp(wait_for=[sentry])
 
     table_info = get_table_info(
         env=env,
@@ -73,7 +74,7 @@ def capture__jae_backup_billingpay(
     table_info = get_raw_backup_billingpay(
         table_info=table_info,
         database_config=database_config,
-        timestamp=timestamp,
+        end_timestamp=end_timestamp,
     )
 
     table_info = upload_backup_billingpay(
@@ -86,5 +87,5 @@ def capture__jae_backup_billingpay(
         env=env,
         table_info=table_info,
         database_name=database_name,
-        timestamp=timestamp,
+        end_timestamp=end_timestamp,
     )

--- a/pipelines/capture__jae_backup_billingpay/tasks.py
+++ b/pipelines/capture__jae_backup_billingpay/tasks.py
@@ -263,7 +263,7 @@ def get_raw_backup_billingpay(
     Args:
         table_info (list[dict[str, str]]): Lista com as informações das tabelas
         database_config (dict): Dicionário com os argumentos para a função create_database_url
-        end_timestamp (datetime) Timestamp final da captura
+        end_timestamp (datetime): Timestamp final da captura
 
     Returns:
         list[dict[str, str]]: Lista com as informações das tabelas atualizada

--- a/pipelines/capture__jae_backup_billingpay/tasks.py
+++ b/pipelines/capture__jae_backup_billingpay/tasks.py
@@ -254,7 +254,7 @@ As seguintes tabelas não possuem filtros:
 def get_raw_backup_billingpay(
     table_info: list[dict[str, str]],
     database_config: dict[str, str],
-    timestamp: datetime,
+    end_timestamp: datetime,
 ) -> list[dict[str, str]]:
     """
     Captura os dados das tabelas do banco informado
@@ -262,7 +262,7 @@ def get_raw_backup_billingpay(
     Args:
         table_info (list[dict[str, str]]): Lista com as informações das tabelas
         database_config (dict): Dicionário com os argumentos para a função create_database_url
-        timestamp (datetime): Timestamp de referência da execução
+        end_timestamp (datetime) Timestamp final da captura
 
     Returns:
         list[dict[str, str]]: Lista com as informações das tabelas atualizada
@@ -283,7 +283,7 @@ def get_raw_backup_billingpay(
             timestamp_str = (
                 table.get(
                     "last_value",
-                    timestamp,
+                    end_timestamp,
                 )
                 .astimezone(tz=timezone("UTC"))
                 .strftime("%Y-%m-%d %H:%M:%S")
@@ -360,7 +360,7 @@ def set_redis_backup_billingpay(
     env: str,
     table_info: list[dict[str, str]],
     database_name: str,
-    timestamp: datetime,
+    end_timestamp: datetime,
 ):
     """
     Atualiza o Redis com os novos dados capturados
@@ -369,7 +369,7 @@ def set_redis_backup_billingpay(
         env (str): prod ou dev
         table_info (list[dict[str, str]]): Lista de dicionários com as informações das tabelas
         database_name (str): Nome do banco de dados
-        timestamp (datetime): Timestamp de referência da execução
+        end_timestamp (datetime): Timestamp final da captura
     """
     for table in table_info:
         if table["incremental_type"] is None:
@@ -378,7 +378,9 @@ def set_redis_backup_billingpay(
         redis_client = get_redis_client()
         content = redis_client.get(redis_key)
         if table["incremental_type"] == "datetime":
-            save_value = timestamp.strftime(treatment_constants.MATERIALIZATION_LAST_RUN_PATTERN)
+            save_value = end_timestamp.strftime(
+                treatment_constants.MATERIALIZATION_LAST_RUN_PATTERN
+            )
         else:
             save_value = table["redis_save_value"]
 

--- a/pipelines/common/tasks.py
+++ b/pipelines/common/tasks.py
@@ -184,6 +184,9 @@ def task_send_discord_message(message: str, webhook: str):
         webhook (str): Nome da key do webhook no secret
     """
 
+    if is_running_locally():
+        message = "[DEV] " + message
+
     webhook_secret = get_env_secret(constants.WEBHOOKS_SECRET_PATH)
     webhook_url = webhook_secret[webhook]
 

--- a/pipelines/control__jae_verificacao_captura/.dockerignore
+++ b/pipelines/control__jae_verificacao_captura/.dockerignore
@@ -1,0 +1,12 @@
+.direnv/
+.env
+.envrc
+.git/
+.github/
+.mergify.yml
+.venv
+Dockerfile
+README.md
+docs/
+flake.lock
+flake.nix

--- a/pipelines/control__jae_verificacao_captura/CHANGELOG.md
+++ b/pipelines/control__jae_verificacao_captura/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog - control__jae_verificacao_captura
+
+## [1.0.0] - 2026-03-17
+
+### Adicionado
+
+- Cria flow `control__jae_verificacao_captura`

--- a/pipelines/control__jae_verificacao_captura/Dockerfile
+++ b/pipelines/control__jae_verificacao_captura/Dockerfile
@@ -8,8 +8,16 @@ COPY ./pyproject.toml ./uv.lock /opt/prefect/pipelines_v3/
 
 COPY ./pipelines/control__jae_verificacao_captura ./pipelines/control__jae_verificacao_captura/
 
+COPY ./pipelines/capture__jae_auxiliar ./pipelines/capture__jae_auxiliar/
+
+COPY ./pipelines/capture__jae_gps_validador ./pipelines/capture__jae_gps_validador/
+
+COPY ./pipelines/capture__jae_lancamento ./pipelines/capture__jae_lancamento/
+
+COPY ./pipelines/capture__jae_transacao ./pipelines/capture__jae_transacao/
+
+COPY ./pipelines/capture__jae_transacao_riocard ./pipelines/capture__jae_transacao_riocard/
+
 COPY ./pipelines/common/ ./pipelines/common/
-
-
 
 RUN uv sync --all-packages

--- a/pipelines/control__jae_verificacao_captura/Dockerfile
+++ b/pipelines/control__jae_verificacao_captura/Dockerfile
@@ -1,0 +1,15 @@
+FROM ghcr.io/rj-smtr/pipelines_v3:latest
+
+LABEL org.opencontainers.image.source=https://github.com/rj-smtr/pipelines_v3
+
+WORKDIR /opt/prefect/pipelines_v3
+
+COPY ./pyproject.toml ./uv.lock /opt/prefect/pipelines_v3/
+
+COPY ./pipelines/control__jae_verificacao_captura ./pipelines/control__jae_verificacao_captura/
+
+COPY ./pipelines/common/ ./pipelines/common/
+
+
+
+RUN uv sync --all-packages

--- a/pipelines/control__jae_verificacao_captura/Dockerfile
+++ b/pipelines/control__jae_verificacao_captura/Dockerfile
@@ -16,6 +16,8 @@ COPY ./pipelines/capture__jae_lancamento ./pipelines/capture__jae_lancamento/
 
 COPY ./pipelines/capture__jae_transacao ./pipelines/capture__jae_transacao/
 
+COPY ./pipelines/capture__jae_transacao_erro ./pipelines/capture__jae_transacao_erro/
+
 COPY ./pipelines/capture__jae_transacao_riocard ./pipelines/capture__jae_transacao_riocard/
 
 COPY ./pipelines/common/ ./pipelines/common/

--- a/pipelines/control__jae_verificacao_captura/constants.py
+++ b/pipelines/control__jae_verificacao_captura/constants.py
@@ -71,7 +71,7 @@ CHECK_CAPTURE_PARAMS = {
         "final_timestamp_exclusive": True,
     },
     jae_constants.TRANSACAO_ERRO_TABLE_ID: {
-        "source": transacao_constants.TRANSACAO_SOURCE,
+        "source": transacao_erro_constants.JAE_TRANSACAO_ERRO_SOURCE,
         "datalake_table": "rj-smtr.bilhetagem_staging.transacao_erro",
         "timestamp_column": "dt_inclusao",
         "primary_keys": transacao_erro_constants.JAE_TRANSACAO_ERRO_SOURCE.primary_keys,

--- a/pipelines/control__jae_verificacao_captura/constants.py
+++ b/pipelines/control__jae_verificacao_captura/constants.py
@@ -7,6 +7,7 @@ from pipelines.capture__jae_auxiliar import constants as auxiliar_constants
 from pipelines.capture__jae_gps_validador import constants as gps_validador_constants
 from pipelines.capture__jae_lancamento import constants as lancamento_constants
 from pipelines.capture__jae_transacao import constants as transacao_constants
+from pipelines.capture__jae_transacao_erro import constants as transacao_erro_constants
 from pipelines.capture__jae_transacao_riocard import constants as transacao_riocard_constants
 from pipelines.common.capture.jae import constants as jae_constants
 
@@ -67,6 +68,13 @@ CHECK_CAPTURE_PARAMS = {
             "ifnull(id_lancamento, concat(string(dt_lancamento), '_', id_movimento))",
             "id_conta",
         ],
+        "final_timestamp_exclusive": True,
+    },
+    jae_constants.TRANSACAO_ERRO_TABLE_ID: {
+        "source": transacao_constants.TRANSACAO_SOURCE,
+        "datalake_table": "rj-smtr.bilhetagem_staging.transacao_erro",
+        "timestamp_column": "dt_inclusao",
+        "primary_keys": transacao_erro_constants.JAE_TRANSACAO_ERRO_SOURCE.primary_keys,
         "final_timestamp_exclusive": True,
     },
     jae_constants.CLIENTE_TABLE_ID: {

--- a/pipelines/control__jae_verificacao_captura/constants.py
+++ b/pipelines/control__jae_verificacao_captura/constants.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+"""
+Constantes para o flow de verificação da captura dos dados da Jaé
+"""
+
+from pipelines.capture__jae_auxiliar import constants as auxiliar_constants
+from pipelines.capture__jae_gps_validador import constants as gps_validador_constants
+from pipelines.capture__jae_lancamento import constants as lancamento_constants
+from pipelines.capture__jae_transacao import constants as transacao_constants
+from pipelines.capture__jae_transacao_riocard import constants as transacao_riocard_constants
+from pipelines.common.capture.jae import constants as jae_constants
+
+RESULTADO_VERIFICACAO_CAPTURA_TABLE_ID = "resultado_verificacao_captura_jae"
+
+CLIENTE_SOURCE = next(
+    s
+    for s in auxiliar_constants.JAE_AUXILIAR_SOURCES
+    if s.table_id == jae_constants.CLIENTE_TABLE_ID
+)
+
+GRATUIDADE_SOURCE = next(
+    s
+    for s in auxiliar_constants.JAE_AUXILIAR_SOURCES
+    if s.table_id == jae_constants.GRATUIDADE_TABLE_ID
+)
+
+ESTUDANTE_SOURCE = next(
+    s
+    for s in auxiliar_constants.JAE_AUXILIAR_SOURCES
+    if s.table_id == jae_constants.ESTUDANTE_TABLE_ID
+)
+
+LAUDO_PCD_SOURCE = next(
+    s
+    for s in auxiliar_constants.JAE_AUXILIAR_SOURCES
+    if s.table_id == jae_constants.LAUDO_PCD_TABLE_ID
+)
+
+
+CHECK_CAPTURE_PARAMS = {
+    jae_constants.TRANSACAO_TABLE_ID: {
+        "source": transacao_constants.TRANSACAO_SOURCE,
+        "datalake_table": "rj-smtr.bilhetagem_staging.transacao",
+        "timestamp_column": "data_processamento",
+        "primary_keys": transacao_constants.TRANSACAO_SOURCE.primary_keys,
+        "final_timestamp_exclusive": True,
+    },
+    jae_constants.TRANSACAO_RIOCARD_TABLE_ID: {
+        "source": transacao_riocard_constants.TRANSACAO_RIOCARD_SOURCE,
+        "datalake_table": "rj-smtr.bilhetagem_staging.transacao_riocard",
+        "timestamp_column": "data_processamento",
+        "primary_keys": transacao_riocard_constants.TRANSACAO_RIOCARD_SOURCE.primary_keys,
+        "final_timestamp_exclusive": True,
+    },
+    jae_constants.GPS_VALIDADOR_TABLE_ID: {
+        "source": gps_validador_constants.GPS_VALIDADOR_SOURCE,
+        "datalake_table": "rj-smtr.monitoramento_staging.gps_validador",
+        "timestamp_column": "data_tracking",
+        "primary_keys": gps_validador_constants.GPS_VALIDADOR_SOURCE.primary_keys,
+        "final_timestamp_exclusive": True,
+    },
+    jae_constants.LANCAMENTO_TABLE_ID: {
+        "source": lancamento_constants.LANCAMENTO_SOURCE,
+        "datalake_table": "rj-smtr.bilhetagem_interno_staging.lancamento",
+        "timestamp_column": "dt_lancamento",
+        "primary_keys": [
+            "ifnull(id_lancamento, concat(string(dt_lancamento), '_', id_movimento))",
+            "id_conta",
+        ],
+        "final_timestamp_exclusive": True,
+    },
+    jae_constants.CLIENTE_TABLE_ID: {
+        "source": CLIENTE_SOURCE,
+        "datalake_table": "rj-smtr.cadastro_interno_staging.cliente",
+        "timestamp_column": "dt_cadastro",
+        "primary_keys": CLIENTE_SOURCE.primary_keys,
+        "final_timestamp_exclusive": False,
+    },
+    jae_constants.GRATUIDADE_TABLE_ID: {
+        "source": GRATUIDADE_SOURCE,
+        "datalake_table": "rj-smtr.bilhetagem_staging.gratuidade",
+        "timestamp_column": "data_inclusao",
+        "primary_keys": GRATUIDADE_SOURCE.primary_keys,
+        "final_timestamp_exclusive": False,
+    },
+    jae_constants.ESTUDANTE_TABLE_ID: {
+        "source": ESTUDANTE_SOURCE,
+        "datalake_table": "rj-smtr.bilhetagem_staging.estudante",
+        "timestamp_column": "data_inclusao",
+        "primary_keys": ["cd_cliente", "data_inclusao"],
+        "final_timestamp_exclusive": False,
+    },
+    jae_constants.LAUDO_PCD_TABLE_ID: {
+        "source": LAUDO_PCD_SOURCE,
+        "datalake_table": "rj-smtr.bilhetagem_staging.laudo_pcd",
+        "timestamp_column": "data_inclusao",
+        "primary_keys": LAUDO_PCD_SOURCE.primary_keys,
+        "final_timestamp_exclusive": False,
+    },
+}

--- a/pipelines/control__jae_verificacao_captura/flow.py
+++ b/pipelines/control__jae_verificacao_captura/flow.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+from typing import Iterable, Optional
+
+from prefect import flow, runtime, unmapped
+
+from pipelines.common.capture.jae import constants as jae_constants
+from pipelines.common.tasks import (
+    get_run_env,
+    get_scheduled_timestamp,
+    initialize_sentry,
+    setup_environment,
+    task_send_discord_message,
+)
+from pipelines.control__jae_verificacao_captura import constants
+from pipelines.control__jae_verificacao_captura.tasks import (
+    create_capture_check_discord_message,
+    get_capture_gaps,
+    jae_capture_check_get_ts_range,
+)
+from pipelines.control__jae_verificacao_captura.utils import rename_capture_check_flow_run
+
+table_ids = constants.CHECK_CAPTURE_PARAMS.keys()
+
+
+@flow(log_prints=True, flow_run_name=rename_capture_check_flow_run)
+def control__jae_verificacao_captura(
+    env: Optional[str] = None,
+    timestamp_captura_start: Optional[str] = None,
+    timestamp_captura_end: Optional[str] = None,
+    table_ids: Iterable = tuple(table_ids),
+    retroactive_days: int = 1,
+):
+    env = get_run_env(env=env, deployment_name=runtime.deployment.name)
+    sentry = initialize_sentry(env=env)
+    setup_environment(env=env)
+
+    timestamp = get_scheduled_timestamp(wait_for=[sentry])
+
+    timestamp_captura_start, timestamp_captura_end = jae_capture_check_get_ts_range(
+        timestamp=timestamp,
+        retroactive_days=retroactive_days,
+        timestamp_captura_start=timestamp_captura_start,
+        timestamp_captura_end=timestamp_captura_end,
+    )
+
+    timestamps = get_capture_gaps.map(
+        env=unmapped(env),
+        table_id=table_ids,
+        timestamp_captura_start=unmapped(timestamp_captura_start),
+        timestamp_captura_end=unmapped(timestamp_captura_end),
+    )
+
+    discord_messages = create_capture_check_discord_message.map(
+        table_id=table_ids,
+        timestamps=timestamps,
+        timestamp_captura_start=unmapped(timestamp_captura_start),
+        timestamp_captura_end=unmapped(timestamp_captura_end),
+    )
+
+    task_send_discord_message.map(
+        message=discord_messages,
+        key=unmapped(jae_constants.ALERT_WEBHOOK),
+    )

--- a/pipelines/control__jae_verificacao_captura/flow.py
+++ b/pipelines/control__jae_verificacao_captura/flow.py
@@ -1,4 +1,10 @@
 # -*- coding: utf-8 -*-
+"""
+Flow de verificação da captura dos dados da Jaé
+
+Common: 2026-03-18
+"""
+
 from typing import Iterable, Optional
 
 from prefect import flow, runtime, unmapped

--- a/pipelines/control__jae_verificacao_captura/flow.py
+++ b/pipelines/control__jae_verificacao_captura/flow.py
@@ -5,7 +5,7 @@ Flow de verificação da captura dos dados da Jaé
 Common: 2026-03-18
 """
 
-from typing import Iterable, Optional
+from typing import Optional
 
 from prefect import flow, runtime, unmapped
 
@@ -33,7 +33,7 @@ def control__jae_verificacao_captura(
     env: Optional[str] = None,
     timestamp_captura_start: Optional[str] = None,
     timestamp_captura_end: Optional[str] = None,
-    table_ids: Iterable = tuple(table_ids),
+    table_ids: list = tuple(table_ids),
     retroactive_days: int = 1,
 ):
     env = get_run_env(env=env, deployment_name=runtime.deployment.name)
@@ -49,12 +49,13 @@ def control__jae_verificacao_captura(
         timestamp_captura_end=timestamp_captura_end,
     )
 
-    timestamps = get_capture_gaps.map(
+    timestamps_future = get_capture_gaps.map(
         env=unmapped(env),
         table_id=table_ids,
         timestamp_captura_start=unmapped(timestamp_captura_start),
         timestamp_captura_end=unmapped(timestamp_captura_end),
     )
+    timestamps = timestamps_future.result()
 
     discord_messages = create_capture_check_discord_message.map(
         table_id=table_ids,
@@ -65,5 +66,5 @@ def control__jae_verificacao_captura(
 
     task_send_discord_message.map(
         message=discord_messages,
-        key=unmapped(jae_constants.ALERT_WEBHOOK),
+        webhook=unmapped(jae_constants.ALERT_WEBHOOK),
     )

--- a/pipelines/control__jae_verificacao_captura/prefect.yaml
+++ b/pipelines/control__jae_verificacao_captura/prefect.yaml
@@ -1,0 +1,55 @@
+name: control__jae_verificacao_captura
+prefect-version: 3.4.8
+
+build:
+  - prefect.deployments.steps.run_shell_script:
+      id: get-commit-hash
+      script: git rev-parse --short HEAD
+      stream_output: false
+  - prefect_docker.deployments.steps.build_docker_image:
+      id: build-image
+      requires: prefect-docker>=0.6.5
+      image_name: ghcr.io/rj-smtr/pipelines_v3/deployments
+      tag: "control__jae_verificacao_captura-{{ get-commit-hash.stdout }}"
+      dockerfile: pipelines/control__jae_verificacao_captura/Dockerfile
+
+push:
+  - prefect_docker.deployments.steps.push_docker_image:
+      requires: prefect-docker>=0.6.5
+      image_name: "{{ build-image.image_name }}"
+      tag: "{{ build-image.tag }}"
+
+pull:
+  - prefect.deployments.steps.set_working_directory:
+      directory: /opt/prefect/pipelines_v3
+
+deployments:
+  - name: rj-control--jae_verificacao_captura--staging
+    version: "{{ build-image.tag }}"
+    entrypoint: pipelines/control__jae_verificacao_captura/flow.py:control__jae_verificacao_captura
+    work_pool:
+      name: smtr-pool
+      work_queue_name: default
+      job_variables:
+        image: "{{ build-image.image_name }}:{{ build-image.tag }}"
+        command: uv run --package control__jae_verificacao_captura -- prefect flow-run execute
+        secretName: prefect-jobs-secrets-staging
+        image_pull_policy: Always
+  - name: rj-control--jae_verificacao_captura--prod
+    version: "{{ get-commit-hash.stdout }}"
+    entrypoint: pipelines/control__jae_verificacao_captura/flow.py:control__jae_verificacao_captura
+    schedules:
+      - cron: "0 5 * * *"
+        timezone: "America/Sao_Paulo"
+    work_pool:
+      name: smtr-pool
+      work_queue_name: default
+      job_variables:
+        image: "{{ build-image.image_name }}:{{ build-image.tag }}"
+        command: uv run --package control__jae_verificacao_captura -- prefect flow-run execute
+        secretName: prefect-jobs-secrets
+        image_pull_policy: Always
+        cpu_limit: "1000m"
+        memory_limit: "4600Mi"
+        cpu_request: "500m"
+        memory_request: "1000Mi"

--- a/pipelines/control__jae_verificacao_captura/pyproject.toml
+++ b/pipelines/control__jae_verificacao_captura/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "control__jae_verificacao_captura"
+version = "0.1.0"
+description = "Pipeline jae_verificacao_captura da secretaria rj-smtr"

--- a/pipelines/control__jae_verificacao_captura/tasks.py
+++ b/pipelines/control__jae_verificacao_captura/tasks.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 import pandas_gbq
 from prefect import runtime, task
+from prefect.cache_policies import NO_CACHE
 
 from pipelines.common import constants as smtr_constants
 from pipelines.common.utils.utils import convert_timezone
@@ -16,7 +17,7 @@ from pipelines.control__jae_verificacao_captura.utils import (
 )
 
 
-@task
+@task(cache_policy=NO_CACHE)
 def jae_capture_check_get_ts_range(
     timestamp: datetime,
     retroactive_days: int,
@@ -59,7 +60,7 @@ def jae_capture_check_get_ts_range(
     return start, end
 
 
-@task
+@task(cache_policy=NO_CACHE)
 def get_capture_gaps(
     env: str,
     table_id: str,
@@ -176,7 +177,7 @@ def get_capture_gaps(
     return timestamps
 
 
-@task
+@task(cache_policy=NO_CACHE)
 def create_capture_check_discord_message(
     table_id: str,
     timestamps: list[dict],

--- a/pipelines/control__jae_verificacao_captura/tasks.py
+++ b/pipelines/control__jae_verificacao_captura/tasks.py
@@ -1,0 +1,217 @@
+# -*- coding: utf-8 -*-
+"""Tasks para o flow de verificação da captura dos dados da Jaé"""
+
+from datetime import datetime, timedelta
+from typing import Optional
+
+import pandas_gbq
+from prefect import runtime, task
+
+from pipelines.common import constants as smtr_constants
+from pipelines.common.utils.utils import convert_timezone
+from pipelines.control__jae_verificacao_captura import constants
+from pipelines.control__jae_verificacao_captura.utils import (
+    get_jae_timestamp_captura_count,
+    save_capture_check_results,
+)
+
+
+@task
+def jae_capture_check_get_ts_range(
+    timestamp: datetime,
+    retroactive_days: int,
+    timestamp_captura_start: Optional[str],
+    timestamp_captura_end: Optional[str],
+) -> tuple[datetime, datetime]:
+    """
+    Calcula o intervalo de para checagem da captura dos dados da Jaé.
+
+    Args:
+        timestamp (datetime): Data e hora de execução do flow
+        retroactive_days (int): Número de dias a subtrair de `timestamp` para definir
+            o início do intervalo
+        timestamp_captura_start (Optional[str]): Parâmetro do flow para definição
+            de timestamp inicial de forma manual
+        timestamp_captura_end (Optional[str]): Parâmetro do flow para definição
+            de timestamp final de forma manual
+
+    Returns:
+        tuple[datetime, datetime]: Intervalo com:
+            - start (datetime): Início do intervalo
+            - end (datetime): Fim do intervalo
+    """
+    if timestamp_captura_start is not None:
+        start = datetime.fromisoformat(timestamp_captura_start)
+    else:
+        start = (timestamp - timedelta(days=retroactive_days)).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+
+    start = convert_timezone(timestamp=start)
+
+    if timestamp_captura_end is not None:
+        end = datetime.fromisoformat(timestamp_captura_end)
+    else:
+        end = start.replace(hour=23, minute=59, second=59, microsecond=0)
+
+    end = convert_timezone(timestamp=end)
+
+    return start, end
+
+
+@task
+def get_capture_gaps(
+    env: str,
+    table_id: str,
+    timestamp_captura_start: datetime,
+    timestamp_captura_end: datetime,
+) -> list[str]:
+    """
+    Identifica timestamps com divergência entre os dados presentes
+    na base da Jaé e os dados capturados no datalake.
+
+    Args:
+        env (str): prod ou dev
+        table_id (str): Nome da tabela no BigQuery
+        timestamp_captura_start (datetime): Início do intervalo de verificação
+        timestamp_captura_end (datetime): Fim do intervalo de verificação
+
+    Returns:
+        list[str]: Lista de strings no formato `%Y-%m-%d %H:%M:%S` representando os timestamps
+        com divergência de contagem entre JAE e datalake
+    """
+    params = constants.CHECK_CAPTURE_PARAMS.value[table_id]
+    timestamp_column = params["timestamp_column"]
+    source = params["source"]
+    df_jae = get_jae_timestamp_captura_count(
+        source=source,
+        timestamp_column=timestamp_column,
+        timestamp_captura_start=timestamp_captura_start,
+        timestamp_captura_end=timestamp_captura_end,
+        final_timestamp_exclusive=params["final_timestamp_exclusive"],
+    )
+
+    primary_keys = params.get("primary_keys")
+    if primary_keys is None:
+        primary_keys = "1"
+    elif len(primary_keys) == 1:
+        primary_keys = f"DISTINCT {primary_keys[0]}"
+    else:
+        primary_keys = f"DISTINCT TO_JSON_STRING(STRUCT({', '.join(primary_keys)}))"
+
+    query_datalake = f"""
+    WITH contagens AS (
+        SELECT
+            timestamp_captura,
+            COUNT({primary_keys}) AS total_datalake
+        FROM
+            {params["datalake_table"]}
+        WHERE
+            DATA BETWEEN '{timestamp_captura_start.date().isoformat()}'
+            AND '{timestamp_captura_end.date().isoformat()}'
+            AND timestamp_captura BETWEEN '{timestamp_captura_start.strftime("%Y-%m-%d %H:%M:%S")}'
+            AND '{timestamp_captura_end.strftime("%Y-%m-%d %H:%M:%S")}'
+        GROUP BY
+            1
+    ),
+    timestamps_captura AS (
+        SELECT
+            DATETIME(timestamp_captura) AS timestamp_captura
+        FROM
+            UNNEST(
+                GENERATE_TIMESTAMP_ARRAY(
+                    '{timestamp_captura_start.strftime("%Y-%m-%d %H:%M:%S")}',
+                    '{timestamp_captura_end.strftime("%Y-%m-%d %H:%M:%S")}',
+                    INTERVAL 1 minute
+                )
+            ) AS timestamp_captura
+    )
+    SELECT
+        timestamp_captura,
+        COALESCE(total_datalake, 0) AS total_datalake
+    FROM
+        timestamps_captura
+    LEFT JOIN
+        contagens
+    USING
+        (timestamp_captura)
+    """
+
+    print(f"Executando query\n{query_datalake}")
+
+    df_datalake = pandas_gbq.read_gbq(
+        query_datalake,
+        project_id=smtr_constants.PROJECT_NAME.value[env],
+    )
+
+    df_datalake["timestamp_captura"] = df_datalake["timestamp_captura"].dt.tz_localize(
+        smtr_constants.TIMEZONE.value
+    )
+
+    df_merge = df_jae.merge(df_datalake, how="left", on="timestamp_captura")
+    df_merge["table_id"] = table_id
+    df_merge["total_datalake"] = df_merge["total_datalake"].astype(int)
+    df_merge["total_jae"] = df_merge["total_jae"].astype(int)
+    df_merge["indicador_captura_correta"] = df_merge["total_datalake"] == df_merge["total_jae"]
+
+    timestamps = (
+        df_merge.loc[~df_merge["indicador_captura_correta"]]
+        .sort_values(by=["timestamp_captura"])["timestamp_captura"]
+        .dt.strftime("%Y-%m-%d %H:%M:%S")
+        .tolist()
+    )
+
+    save_capture_check_results(env=env, results=df_merge)
+
+    if len(timestamps) > 0:
+        ts_log = [f'"{t}",' for t in timestamps]
+        print(
+            "[{table_id}] Os seguintes timestamps estão divergentes:\n{timestamps_str}".format(
+                table_id=table_id, timestamps_str="\n".join(ts_log)
+            )
+        )
+    else:
+        print(f"[{table_id}] Todos os dados foram capturados com sucesso!")
+
+    return timestamps
+
+
+@task
+def create_capture_check_discord_message(
+    table_id: str,
+    timestamps: list[dict],
+    timestamp_captura_start: datetime,
+    timestamp_captura_end: datetime,
+) -> str:
+    """
+    Cria a mensagem para notificação no Discord com o resultado da verificação de captura de dados
+
+    Args:
+        table_id (str): Nome da tabela no BigQuery
+        timestamps (list[dict]): Lista de timestamps com falhas na captura
+        timestamp_captura_start (datetime): Início do intervalo analisado
+        timestamp_captura_end (datetime): Fim do intervalo analisado
+
+    Returns:
+        str: Mensagem para ser enviada no Discord
+    """
+    timestamps_len = len(timestamps)
+    message = f"""
+Tabela: {table_id}
+De {timestamp_captura_start.isoformat()} até {timestamp_captura_end.isoformat()}
+Foram encontradas {timestamps_len} timestamps com dados faltantes
+"""
+    if timestamps_len > 0:
+        mentions_tag = (
+            f" - <@&{smtr_constants.OWNERS_DISCORD_MENTIONS.value['dados_smtr']['user_id']}>"
+        )
+        message = f":red_circle: {message}"
+        message += (
+            "\n"
+            + f"https://prefect.mobilidade.rio/runs/flow-run/{runtime.flow_run.id}"
+            + "\n"
+            + mentions_tag
+        )
+    else:
+        message = f":green_circle: {message}"
+    return message

--- a/pipelines/control__jae_verificacao_captura/tasks.py
+++ b/pipelines/control__jae_verificacao_captura/tasks.py
@@ -189,7 +189,7 @@ def create_capture_check_discord_message(
 
     Args:
         table_id (str): Nome da tabela no BigQuery
-        timestamps (list[dict]): Lista de timestamps com falhas na captura
+        timestamps (list[str]): Lista de timestamps com falhas na captura
         timestamp_captura_start (datetime): Início do intervalo analisado
         timestamp_captura_end (datetime): Fim do intervalo analisado
 

--- a/pipelines/control__jae_verificacao_captura/tasks.py
+++ b/pipelines/control__jae_verificacao_captura/tasks.py
@@ -81,7 +81,7 @@ def get_capture_gaps(
         list[str]: Lista de strings no formato `%Y-%m-%d %H:%M:%S` representando os timestamps
         com divergência de contagem entre JAE e datalake
     """
-    params = constants.CHECK_CAPTURE_PARAMS.value[table_id]
+    params = constants.CHECK_CAPTURE_PARAMS[table_id]
     timestamp_column = params["timestamp_column"]
     source = params["source"]
     df_jae = get_jae_timestamp_captura_count(
@@ -142,11 +142,11 @@ def get_capture_gaps(
 
     df_datalake = pandas_gbq.read_gbq(
         query_datalake,
-        project_id=smtr_constants.PROJECT_NAME.value[env],
+        project_id=smtr_constants.PROJECT_NAME[env],
     )
 
     df_datalake["timestamp_captura"] = df_datalake["timestamp_captura"].dt.tz_localize(
-        smtr_constants.TIMEZONE.value
+        smtr_constants.TIMEZONE
     )
 
     df_merge = df_jae.merge(df_datalake, how="left", on="timestamp_captura")
@@ -203,9 +203,7 @@ De {timestamp_captura_start.isoformat()} até {timestamp_captura_end.isoformat()
 Foram encontradas {timestamps_len} timestamps com dados faltantes
 """
     if timestamps_len > 0:
-        mentions_tag = (
-            f" - <@&{smtr_constants.OWNERS_DISCORD_MENTIONS.value['dados_smtr']['user_id']}>"
-        )
+        mentions_tag = f" - <@&{smtr_constants.OWNERS_DISCORD_MENTIONS['dados_smtr']['user_id']}>"
         message = f":red_circle: {message}"
         message += (
             "\n"

--- a/pipelines/control__jae_verificacao_captura/tasks.py
+++ b/pipelines/control__jae_verificacao_captura/tasks.py
@@ -180,7 +180,7 @@ def get_capture_gaps(
 @task(cache_policy=NO_CACHE)
 def create_capture_check_discord_message(
     table_id: str,
-    timestamps: list[dict],
+    timestamps: list[str],
     timestamp_captura_start: datetime,
     timestamp_captura_end: datetime,
 ) -> str:

--- a/pipelines/control__jae_verificacao_captura/utils.py
+++ b/pipelines/control__jae_verificacao_captura/utils.py
@@ -164,56 +164,56 @@ def get_jae_timestamp_captura_count_query(  # noqa: PLR0913
                     AND tc.timestamp_final
             """
 
-            return f"""
-                WITH RECURSIVE timestamps_captura AS (
-                    SELECT
-                        TIMESTAMP('{{timestamp_captura_start}}') AS timestamp_captura,
-                        DATE_SUB(
-                            TIMESTAMP('{{timestamp_captura_start}}'),
-                            INTERVAL ({delay_query} + {capture_interval_minutes}) MINUTE
-                        ) AS timestamp_inicial,
-                        DATE_SUB(
-                            TIMESTAMP('{{timestamp_captura_start}}'),
-                            INTERVAL ({delay_query}) MINUTE
-                        ) AS timestamp_final
-                    UNION ALL
-                    SELECT
-                        timestamp_captura + INTERVAL {capture_interval_minutes} MINUTE,
-                        DATE_SUB(
-                            timestamp_captura  + INTERVAL {capture_interval_minutes} MINUTE,
-                            INTERVAL ({delay_query} + {capture_interval_minutes}) MINUTE
-                        ) AS timestamp_inicial,
-                        DATE_SUB(
-                            timestamp_captura  + INTERVAL {capture_interval_minutes} MINUTE,
-                            INTERVAL ({delay_query}) MINUTE
-                        ) AS timestamp_final
-                    FROM timestamps_captura
-                    WHERE
-                        timestamp_captura
-                        + INTERVAL {capture_interval_minutes} MINUTE
-                        <= TIMESTAMP('{{timestamp_captura_end}}')
-                ),
-                dados_jae AS (
-                    {capture_query}
-                ),
-                jae_timestamp_captura AS (
-                    SELECT
-                        tc.timestamp_captura,
-                        d.{timestamp_column} as col
-                    FROM
-                        timestamps_captura tc
-                    LEFT JOIN
-                        dados_jae d
-                    ON {join_condition}
-                )
+        return f"""
+            WITH RECURSIVE timestamps_captura AS (
                 SELECT
-                    timestamp_captura,
-                    count(col) AS total_jae
-                FROM
-                    jae_timestamp_captura
-                GROUP BY
+                    TIMESTAMP('{{timestamp_captura_start}}') AS timestamp_captura,
+                    DATE_SUB(
+                        TIMESTAMP('{{timestamp_captura_start}}'),
+                        INTERVAL ({delay_query} + {capture_interval_minutes}) MINUTE
+                    ) AS timestamp_inicial,
+                    DATE_SUB(
+                        TIMESTAMP('{{timestamp_captura_start}}'),
+                        INTERVAL ({delay_query}) MINUTE
+                    ) AS timestamp_final
+                UNION ALL
+                SELECT
+                    timestamp_captura + INTERVAL {capture_interval_minutes} MINUTE,
+                    DATE_SUB(
+                        timestamp_captura  + INTERVAL {capture_interval_minutes} MINUTE,
+                        INTERVAL ({delay_query} + {capture_interval_minutes}) MINUTE
+                    ) AS timestamp_inicial,
+                    DATE_SUB(
+                        timestamp_captura  + INTERVAL {capture_interval_minutes} MINUTE,
+                        INTERVAL ({delay_query}) MINUTE
+                    ) AS timestamp_final
+                FROM timestamps_captura
+                WHERE
                     timestamp_captura
-            """
+                    + INTERVAL {capture_interval_minutes} MINUTE
+                    <= TIMESTAMP('{{timestamp_captura_end}}')
+            ),
+            dados_jae AS (
+                {capture_query}
+            ),
+            jae_timestamp_captura AS (
+                SELECT
+                    tc.timestamp_captura,
+                    d.{timestamp_column} as col
+                FROM
+                    timestamps_captura tc
+                LEFT JOIN
+                    dados_jae d
+                ON {join_condition}
+            )
+            SELECT
+                timestamp_captura,
+                count(col) AS total_jae
+            FROM
+                jae_timestamp_captura
+            GROUP BY
+                timestamp_captura
+        """
 
     else:
         raise NotImplementedError(f"Engine {engine} não implementada")

--- a/pipelines/control__jae_verificacao_captura/utils.py
+++ b/pipelines/control__jae_verificacao_captura/utils.py
@@ -1,0 +1,445 @@
+# -*- coding: utf-8 -*-
+"""Funções para o flow de verificação da captura dos dados da Jaé"""
+
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pandas as pd
+import pandas_gbq
+from croniter import croniter
+from google.cloud import bigquery
+from prefect import runtime
+from pytz import timezone
+
+from pipelines.common import constants as smtr_constants
+from pipelines.common.capture.jae import constants as jae_constants
+from pipelines.common.utils.database import create_database_url, create_engine
+from pipelines.common.utils.gcp.bigquery import SourceTable
+from pipelines.common.utils.secret import get_env_secret
+from pipelines.common.utils.utils import convert_timezone
+from pipelines.control__jae_verificacao_captura import constants
+
+
+def get_capture_interval_minutes(source: SourceTable) -> int:
+    """
+    Retorna o intervalo de captura em minutos calculado a partir do cron do SourceTable.
+
+    Args:
+        source (SourceTable): Objeto que contém a expressão cron na propriedade `schedule_cron`.
+
+    Returns:
+        int: Intervalo entre capturas, em minutos.
+    """
+    cron_expr = source.schedule_cron
+    base_time = datetime.now(tz=ZoneInfo(smtr_constants.TIMEZONE))
+    iterador = croniter(cron_expr, base_time)
+    next_time = iterador.get_next(datetime)
+    prev_time = iterador.get_prev(datetime)
+
+    return (next_time - prev_time).total_seconds() / 60
+
+
+def get_jae_timestamp_captura_count_query(  # noqa: PLR0913
+    engine: str,
+    delay_query: str,
+    capture_interval_minutes: int,
+    capture_query: str,
+    timestamp_column: str,
+    final_timestamp_exclusive: bool,
+) -> str:
+    """
+    Gera uma query SQL para contar os dados da Jaé adaptada para PostgreSQL ou MySQL.
+
+    Args:
+        engine (str): Nome do banco de dados ('postgresql' ou 'mysql').
+        delay_query (str): Expressão SQL usada para calcular o delay da captura.
+        capture_interval_minutes (int): Intervalo de captura em minutos.
+        capture_query (str): Query base que retorna os dados de captura.
+        timestamp_column (str): Nome da coluna de timestamp da tabela.
+
+    Returns:
+        str: Query SQL completa para contar registros agrupados por timestamp_captura.
+    """
+
+    if engine == "postgresql":
+        if final_timestamp_exclusive:
+            count_query = f"""
+                SELECT
+                    TO_TIMESTAMP(
+                        FLOOR(
+                            EXTRACT(
+                                EPOCH FROM {timestamp_column}) / ({capture_interval_minutes} * 60
+                            )
+                        ) * ({capture_interval_minutes} * 60)
+                    )  AT TIME ZONE 'UTC' AS datetime_truncado,
+                    COUNT(1) AS total_jae
+                FROM
+                    dados_jae
+                GROUP BY
+                    1
+
+            """
+        else:
+            count_query = f"""
+                SELECT
+                    datetime_truncado,
+                    COUNT(1) AS total_jae
+                FROM
+                (
+                    SELECT
+                        *,
+                        TO_TIMESTAMP(
+                            FLOOR(
+                                EXTRACT(
+                                    EPOCH FROM {timestamp_column}
+                                )
+                                / ({capture_interval_minutes} * 60)
+                            ) * ({capture_interval_minutes} * 60)
+                        )  AT TIME ZONE 'UTC' AS datetime_truncado
+                    FROM dados_jae
+
+                    UNION ALL
+
+                    SELECT
+                        *,
+                        TO_TIMESTAMP(
+                            FLOOR(
+                                EXTRACT(
+                                    EPOCH FROM {timestamp_column} - interval '1 second'
+                                ) / ({capture_interval_minutes} * 60
+                                )
+                            ) * ({capture_interval_minutes} * 60)
+                        )  AT TIME ZONE 'UTC' AS datetime_truncado
+                    FROM
+                        dados_jae
+                    WHERE
+                        TO_TIMESTAMP(
+                            FLOOR(
+                                EXTRACT(
+                                    EPOCH FROM {timestamp_column})
+                                    / ({capture_interval_minutes} * 60
+                                )
+                            ) * ({capture_interval_minutes} * 60)
+                        )  AT TIME ZONE 'UTC' = {timestamp_column}
+                )
+                GROUP BY
+                        1
+            """
+        return f"""
+            WITH timestamps_captura AS (
+                SELECT timestamp_captura, {delay_query} AS delay
+                FROM (SELECT generate_series(
+                    timestamp '{{timestamp_captura_start}}',
+                    timestamp '{{timestamp_captura_end}}',
+                    interval '{capture_interval_minutes} minute'
+                ) AS timestamp_captura)
+            ),
+            dados_jae AS (
+                {capture_query}
+            ),
+            contagens AS (
+                {count_query}
+            )
+            SELECT
+                tc.timestamp_captura,
+                COALESCE(c.total_jae, 0) AS total_jae
+            FROM
+                timestamps_captura tc
+            LEFT JOIN
+                contagens c
+            ON
+                tc.timestamp_captura = c.datetime_truncado
+                + (tc.delay + {capture_interval_minutes} || ' minutes')::interval
+        """
+
+    elif engine == "mysql":
+        if final_timestamp_exclusive:
+            join_condition = f"""
+                d.{timestamp_column} >= tc.timestamp_inicial AND
+                d.{timestamp_column} < tc.timestamp_final
+            """
+        else:
+            join_condition = f"""
+                d.{timestamp_column} BETWEEN tc.timestamp_inicial
+                    AND tc.timestamp_final
+            """
+
+            return f"""
+                WITH RECURSIVE timestamps_captura AS (
+                    SELECT
+                        TIMESTAMP('{{timestamp_captura_start}}') AS timestamp_captura,
+                        DATE_SUB(
+                            TIMESTAMP('{{timestamp_captura_start}}'),
+                            INTERVAL ({delay_query} + {capture_interval_minutes}) MINUTE
+                        ) AS timestamp_inicial,
+                        DATE_SUB(
+                            TIMESTAMP('{{timestamp_captura_start}}'),
+                            INTERVAL ({delay_query}) MINUTE
+                        ) AS timestamp_final
+                    UNION ALL
+                    SELECT
+                        timestamp_captura + INTERVAL {capture_interval_minutes} MINUTE,
+                        DATE_SUB(
+                            timestamp_captura  + INTERVAL {capture_interval_minutes} MINUTE,
+                            INTERVAL ({delay_query} + {capture_interval_minutes}) MINUTE
+                        ) AS timestamp_inicial,
+                        DATE_SUB(
+                            timestamp_captura  + INTERVAL {capture_interval_minutes} MINUTE,
+                            INTERVAL ({delay_query}) MINUTE
+                        ) AS timestamp_final
+                    FROM timestamps_captura
+                    WHERE
+                        timestamp_captura
+                        + INTERVAL {capture_interval_minutes} MINUTE
+                        <= TIMESTAMP('{{timestamp_captura_end}}')
+                ),
+                dados_jae AS (
+                    {capture_query}
+                ),
+                jae_timestamp_captura AS (
+                    SELECT
+                        tc.timestamp_captura,
+                        d.{timestamp_column} as col
+                    FROM
+                        timestamps_captura tc
+                    LEFT JOIN
+                        dados_jae d
+                    ON {join_condition}
+                )
+                SELECT
+                    timestamp_captura,
+                    count(col) AS total_jae
+                FROM
+                    jae_timestamp_captura
+                GROUP BY
+                    timestamp_captura
+            """
+
+    else:
+        raise NotImplementedError(f"Engine {engine} não implementada")
+
+
+def get_jae_timestamp_captura_count(
+    source: SourceTable,
+    timestamp_column: str,
+    timestamp_captura_start: datetime,
+    timestamp_captura_end: datetime,
+    final_timestamp_exclusive: bool,
+) -> pd.DataFrame:
+    """
+    Retorna a contagem de registros por timestamp_captura de uma tabela da Jaé.
+
+    Args:
+        source (SourceTable): Objeto contendo informações da tabela
+        timestamp_column (str): Nome da coluna de timestamp que os dados capturados são filtrados
+        timestamp_captura_start (datetime): Data e hora inicial da janela de captura
+        timestamp_captura_end (datetime): Data e hora final da janela de captura
+
+    Returns:
+        pd.DataFrame: DataFrame com duas colunas:
+            - `timestamp_captura` (datetime): Coluna timestamp_captura correspondente.
+            - `total_jae` (int): Contagem de registros na base da Jaé.
+    """
+    table_capture_params = jae_constants.JAE_TABLE_CAPTURE_PARAMS[source.table_id]
+    database = table_capture_params["database"]
+    credentials = get_env_secret(jae_constants.JAE_SECRET_PATH)
+    database_settings = jae_constants.JAE_DATABASE_SETTINGS[database]
+    engine = database_settings["engine"]
+    url = create_database_url(
+        engine=engine,
+        host=database_settings["host"],
+        user=credentials["user"],
+        password=credentials["password"],
+        database=database,
+    )
+    connection = create_engine(url)
+    capture_delay_minutes = table_capture_params.get("capture_delay_minutes", {"0": 0})
+    capture_delay_timestamps = [a for a in capture_delay_minutes.keys() if a != "0"]
+
+    if len(capture_delay_timestamps) == 0:
+        delay_query = f"{capture_delay_minutes['0']}"
+    else:
+        delay_query = "CASE\n"
+        for t in [a for a in capture_delay_timestamps if a != "0"]:
+            tc = (
+                convert_timezone(timestamp=datetime.fromisoformat(t))
+                .astimezone(tz=timezone("UTC"))
+                .strftime("%Y-%m-%d %H:%M:%S")
+            )
+            delay_query += f"WHEN timestamp_captura >= '{tc}' THEN {capture_delay_minutes[t]}\n"
+
+        delay_query += f"ELSE {capture_delay_minutes['0']}\nEND"
+
+    delay = (
+        max(*capture_delay_minutes.values())
+        if len(capture_delay_timestamps) > 0
+        else capture_delay_minutes["0"]
+    )
+
+    base_query_jae = get_jae_timestamp_captura_count_query(
+        engine=engine,
+        delay_query=delay_query,
+        capture_interval_minutes=get_capture_interval_minutes(source=source),
+        capture_query=table_capture_params["query"],
+        timestamp_column=timestamp_column,
+        final_timestamp_exclusive=final_timestamp_exclusive,
+    )
+
+    jae_start_ts = timestamp_captura_start
+    jae_result = []
+
+    while jae_start_ts < timestamp_captura_end:
+        jae_end_ts = min(jae_start_ts + timedelta(days=1), timestamp_captura_end)
+
+        jae_start_ts_utc = jae_start_ts.astimezone(tz=timezone("UTC"))
+        jae_end_ts_utc = jae_end_ts.astimezone(tz=timezone("UTC"))
+
+        jae_end_ts_utc_format = (
+            jae_end_ts_utc - timedelta(minutes=1)
+            if jae_end_ts_utc < timestamp_captura_end
+            else jae_end_ts_utc
+        )
+
+        query = base_query_jae.format(
+            timestamp_captura_start=jae_start_ts_utc.strftime("%Y-%m-%d %H:%M:%S"),
+            timestamp_captura_end=jae_end_ts_utc_format.strftime("%Y-%m-%d %H:%M:%S"),
+            start=(
+                jae_start_ts_utc.replace(hour=0, minute=0, second=0, microsecond=0)
+                - timedelta(minutes=delay + 1)
+            ).strftime("%Y-%m-%d %H:%M:%S"),
+            end=(jae_end_ts_utc + timedelta(minutes=delay))
+            .replace(hour=23, minute=59, second=59, microsecond=59)
+            .strftime("%Y-%m-%d %H:%M:%S"),
+            delay=delay,
+        )
+
+        print(f"Executando query\n{query}")
+        df_count_jae = pd.read_sql(
+            sql=query,
+            con=connection,
+        )
+
+        df_count_jae["timestamp_captura"] = (
+            pd.to_datetime(df_count_jae["timestamp_captura"])
+            .dt.tz_localize("UTC")
+            .dt.tz_convert(smtr_constants.TIMEZONE)
+        )
+
+        jae_result.append(df_count_jae)
+
+        jae_start_ts = jae_end_ts
+
+    return pd.concat(jae_result)
+
+
+def save_capture_check_results(env: str, results: pd.DataFrame):
+    """
+    Salva os resultados da verificação de captura no BigQuery.
+
+    Args:
+        env (str): dev ou prod
+        results (pd.DataFrame): DataFrame contendo os resultados da verificação,
+            com as seguintes colunas obrigatórias:
+              - table_id (str): table_id no BigQuery
+              - timestamp_captura (datetime): Data e hora da captura
+              - total_datalake (int): Quantidade total de registros no datalake
+              - total_jae (int): Quantidade total de registros na Jaé
+              - indicador_captura_correta (bool): Se a quantidade de registros é a mesma
+    """
+    project_id = smtr_constants.PROJECT_NAME[env]
+    dataset_id = f"source_{jae_constants.JAE_SOURCE_NAME}"
+    table_id = constants.RESULTADO_VERIFICACAO_CAPTURA_TABLE_ID
+    results = results[
+        [
+            "table_id",
+            "timestamp_captura",
+            "total_datalake",
+            "total_jae",
+            "indicador_captura_correta",
+        ]
+    ]
+
+    now = datetime.now(tz=ZoneInfo(smtr_constants.TIMEZONE)).strftime("%Y%m%d%H%M%S")
+    tmp_table = f"{dataset_id}.tmp_{table_id}_{now}"
+
+    pandas_gbq.to_gbq(
+        results,
+        tmp_table,
+        project_id=project_id,
+        if_exists="replace",
+    )
+
+    start_partition = results["timestamp_captura"].min().date().isoformat()
+    end_partition = results["timestamp_captura"].max().date().isoformat()
+
+    try:
+        pandas_gbq.read_gbq(
+            f"""
+                MERGE {project_id}.{dataset_id}.{table_id} t
+                USING {tmp_table} s
+                ON
+                    t.data BETWEEN '{start_partition}' AND '{end_partition}'
+                    AND t.table_id = s.table_id
+                    AND t.timestamp_captura = DATETIME(s.timestamp_captura, 'America/Sao_Paulo')
+                WHEN MATCHED THEN
+                UPDATE SET
+                    total_datalake = s.total_datalake,
+                    total_jae = s.total_jae,
+                    indicador_captura_correta = s.indicador_captura_correta,
+                    datetime_ultima_atualizacao = CURRENT_DATETIME('America/Sao_Paulo')
+                WHEN
+                    NOT MATCHED
+                    AND DATETIME_DIFF(
+                        CURRENT_DATETIME('America/Sao_Paulo'),
+                        DATETIME(s.timestamp_captura, 'America/Sao_Paulo'),
+                        MINUTE
+                    ) > 300
+                THEN
+                INSERT (
+                    data,
+                    table_id,
+                    timestamp_captura,
+                    total_datalake,
+                    total_jae,
+                    indicador_captura_correta,
+                    datetime_ultima_atualizacao
+                )
+                VALUES (
+                    DATE(DATETIME(timestamp_captura, 'America/Sao_Paulo')),
+                    table_id,
+                    DATETIME(timestamp_captura, 'America/Sao_Paulo'),
+                    total_datalake,
+                    total_jae,
+                    indicador_captura_correta,
+                    CURRENT_DATETIME('America/Sao_Paulo')
+                )
+            """,
+            project_id=project_id,
+        )
+
+    finally:
+        bigquery.Client(project=project_id).delete_table(
+            tmp_table,
+            not_found_ok=True,
+        )
+
+
+def rename_capture_check_flow_run() -> str:
+    """
+    Renomeia a execução do flow de checagem da captura da Jaé
+    """
+    scheduled_start_time = convert_timezone(runtime.flow_run.scheduled_start_time)
+    timestamp_captura_start = runtime.flow_run.parameters["timestamp_captura_start"]
+    timestamp_captura_end = runtime.flow_run.parameters["timestamp_captura_end"]
+    retroactive_days = runtime.flow_run.parameters["retroactive_days"]
+
+    run_name = f"[{scheduled_start_time.strftime('%Y-%m-%d %H-%M-%S')}] Verifica Captura Jaé: "
+
+    if timestamp_captura_start is None and timestamp_captura_end is None:
+        start = scheduled_start_time - timedelta(days=retroactive_days)
+        timestamp_captura_start = start.replace(hour=0, minute=0, second=0, microsecond=0)
+        timestamp_captura_end = start.replace(hour=23, minute=59, second=59, microsecond=0)
+
+    run_name += f"From {timestamp_captura_start} To {timestamp_captura_end}"
+
+    return run_name


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Jaé capture verification flow with per-table checks, automated Discord notifications, and configurable deployments.
  * Added utilities and tasks to compute capture intervals, detect gaps, persist results, and format run names.
* **Bug Fixes**
  * Improved timestamp handling for backup operations when an end time is provided.
* **Chores**
  * Added Dockerfile, .dockerignore, deployment config, project metadata, and changelog entries.
* **Style/Behavior**
  * Local runs now prefix outgoing Discord messages with “[DEV]”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->