### PR TITLE
Staging/altera tempo timeout

### DIFF
--- a/pipelines/treatment__validacao_dados_jae/flow.py
+++ b/pipelines/treatment__validacao_dados_jae/flow.py
@@ -1,4 +1,12 @@
 # -*- coding: utf-8 -*-
+"""
+Flow de materialização de validação de dados da Jaé
+
+Executa o selector DBT 'validacao_dados_jae' para materializar dados no BigQuery.
+
+DBT: 2026-04-28
+"""
+
 from typing import Optional
 
 from prefect import flow

--- a/queries/CHANGELOG.md
+++ b/queries/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - queries
 
+## [1.1.2] - 2026-04-28
+
+### Alterado
+
+- Altera o tempo de timeout da key `job_execution_timeout_seconds` do `profiles.yml` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/132)
+
 ## [1.1.1] - 2025-09-23
 
 ### Alterado

--- a/queries/profiles.yml
+++ b/queries/profiles.yml
@@ -2,7 +2,7 @@ queries:
   outputs:
     dev:
       dataset: dbt
-      job_execution_timeout_seconds: 5400
+      job_execution_timeout_seconds: 14400
       job_retries: 1
       keyfile: /tmp/credentials.json
       location: us
@@ -28,7 +28,7 @@ queries:
             spark.driver.memoryOverhead: 1g
     hmg:
       dataset: dbt
-      job_execution_timeout_seconds: 5400
+      job_execution_timeout_seconds: 14400
       job_retries: 1
       keyfile: /tmp/credentials.json
       location: us
@@ -54,7 +54,7 @@ queries:
             spark.driver.memoryOverhead: 1g
     prod:
       dataset: dbt
-      job_execution_timeout_seconds: 5400
+      job_execution_timeout_seconds: 14400
       job_retries: 1
       keyfile: /tmp/credentials.json
       location: us


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Extended job execution timeout limits across production, staging, and development environments to allow sufficient time for job completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->