### PR TITLE
Ponto facultativo 24/05/2026

### DIFF
--- a/pipelines/treatment__planejamento_diario/flow.py
+++ b/pipelines/treatment__planejamento_diario/flow.py
@@ -8,7 +8,7 @@ Schedule:
 - Diariamente às 1h00 (horário de São Paulo)
 - Depende de dados capturados pela Rio Ônibus
 
-DBT: 2026-04-16
+DBT: 2026-05-04
 """
 
 from prefect import flow

--- a/queries/models/planejamento/CHANGELOG.md
+++ b/queries/models/planejamento/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - planejamento
 
+## [1.7.0] - 2026-05-04
+
+### Alterado
+
+- Alterado o `tipo_dia` no modelo `aux_calendario_manual.sql` de `2024-04-24` -> `Ponto Facultativo` conforme DECRETO RIO Nº 57867 DE 13 DE ABRIL DE 2026 (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/145)
+
 ## [1.6.9] - 2026-03-31
 
 ### Alterado

--- a/queries/models/planejamento/staging/aux_calendario_manual.sql
+++ b/queries/models/planejamento/staging/aux_calendario_manual.sql
@@ -68,6 +68,8 @@ with
                 then "Domingo"  -- 000399.001590/2026-17 - Determinação de tipos dia de Carnaval
                 when data = date(2026, 02, 18)
                 then "Sabado"  -- 000399.001590/2026-17 - Determinação de tipos dia de Carnaval
+                when data = date(2026,04,24)
+                then "Ponto Facultativo" -- DECRETO RIO Nº 57867 DE 13 DE ABRIL DE 2026
             end as tipo_dia,
             case
                 when data between date(2024, 09, 14) and date(2024, 09, 15)

--- a/queries/models/planejamento/staging/aux_calendario_manual.sql
+++ b/queries/models/planejamento/staging/aux_calendario_manual.sql
@@ -68,8 +68,8 @@ with
                 then "Domingo"  -- 000399.001590/2026-17 - Determinação de tipos dia de Carnaval
                 when data = date(2026, 02, 18)
                 then "Sabado"  -- 000399.001590/2026-17 - Determinação de tipos dia de Carnaval
-                when data = date(2026,04,24)
-                then "Ponto Facultativo" -- DECRETO RIO Nº 57867 DE 13 DE ABRIL DE 2026
+                when data = date(2026, 04, 24)
+                then "Ponto Facultativo"  -- DECRETO RIO Nº 57867 DE 13 DE ABRIL DE 2026
             end as tipo_dia,
             case
                 when data between date(2024, 09, 14) and date(2024, 09, 15)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated calendar data to recognize April 24, 2026 as a holiday.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->