### PR TITLE
[HOTFIX] remove data_sources from GPS_SONDA_SELECTOR

### DIFF
--- a/pipelines/capture__veiculo_infracao/constants.py
+++ b/pipelines/capture__veiculo_infracao/constants.py
@@ -44,7 +44,7 @@ SPPO_INFRACAO_SOURCES = [
     SourceTable(
         source_name=veiculo_constants.SPPO_VEICULO_SOURCE_NAME,
         table_id=SPPO_INFRACAO_TABLE_ID,
-        first_timestamp=datetime(2026, 4, 17, 0, 0, 0, tzinfo=ZoneInfo(smtr_constants.TIMEZONE)),
+        first_timestamp=datetime(2026, 4, 30, 0, 0, 0, tzinfo=ZoneInfo(smtr_constants.TIMEZONE)),
         flow_folder_name="capture__veiculo_infracao",
         primary_keys=["id_auto_infracao"],
         pretreatment_reader_args=SPPO_INFRACAO_CSV_ARGS,

--- a/pipelines/capture__veiculo_licenciamento/constants.py
+++ b/pipelines/capture__veiculo_licenciamento/constants.py
@@ -58,7 +58,7 @@ SPPO_LICENCIAMENTO_SOURCES = [
     SourceTable(
         source_name=veiculo_constants.SPPO_VEICULO_SOURCE_NAME,
         table_id=SPPO_LICENCIAMENTO_TABLE_ID,
-        first_timestamp=datetime(2026, 4, 17, 0, 0, 0, tzinfo=ZoneInfo(smtr_constants.TIMEZONE)),
+        first_timestamp=datetime(2026, 4, 30, 0, 0, 0, tzinfo=ZoneInfo(smtr_constants.TIMEZONE)),
         flow_folder_name="capture__veiculo_licenciamento",
         primary_keys=["id_veiculo"],
         pretreatment_reader_args=SPPO_LICENCIAMENTO_CSV_ARGS,

--- a/pipelines/capture__veiculo_sppo_registro_agente_verao/constants.py
+++ b/pipelines/capture__veiculo_sppo_registro_agente_verao/constants.py
@@ -26,7 +26,7 @@ SPPO_REGISTRO_AGENTE_VERAO_SOURCES = [
     SourceTable(
         source_name=veiculo_constants.SPPO_VEICULO_SOURCE_NAME,
         table_id=TABLE_ID,
-        first_timestamp=datetime(2026, 4, 17, 0, 0, 0, tzinfo=ZoneInfo(smtr_constants.TIMEZONE)),
+        first_timestamp=datetime(2026, 4, 30, 0, 0, 0, tzinfo=ZoneInfo(smtr_constants.TIMEZONE)),
         flow_folder_name="capture__veiculo_sppo_registro_agente_verao",
         primary_keys=["datetime_registro", "email"],
         pretreatment_reader_args={

--- a/pipelines/treatment__gps_15_minutos_sppo/constants.py
+++ b/pipelines/treatment__gps_15_minutos_sppo/constants.py
@@ -22,8 +22,4 @@ GPS_15_MINUTOS_SPPO_SELECTOR = DBTSelector(
     initial_datetime=datetime(2026, 4, 29, 10, 0, 0, tzinfo=ZoneInfo(smtr_constants.TIMEZONE)),
     flow_folder_name="treatment__gps_15_minutos_sppo",
     redis_key_suffix="sppo",
-    data_sources=[
-        registros_constants.SPPO_REGISTROS_SOURCE,
-        realocacao_constants.SPPO_REALOCACAO_SOURCE,
-    ],
 )

--- a/pipelines/treatment__gps_15_minutos_sppo/constants.py
+++ b/pipelines/treatment__gps_15_minutos_sppo/constants.py
@@ -6,8 +6,6 @@ Valores constantes para materialização do selector gps_15_minutos SPPO
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
-from pipelines.capture__sppo_realocacao import constants as realocacao_constants
-from pipelines.capture__sppo_registros import constants as registros_constants
 from pipelines.common import constants as smtr_constants
 from pipelines.common.treatment.default_treatment.utils import DBTSelector
 

--- a/pipelines/treatment__gps_sonda/constants.py
+++ b/pipelines/treatment__gps_sonda/constants.py
@@ -6,7 +6,6 @@ Valores constantes para materialização do selector gps Sonda (BRT)
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
-from pipelines.capture__sonda_registros import constants as sonda_constants
 from pipelines.common import constants as smtr_constants
 from pipelines.common.treatment.default_treatment.utils import DBTSelector
 

--- a/pipelines/treatment__gps_sonda/constants.py
+++ b/pipelines/treatment__gps_sonda/constants.py
@@ -22,5 +22,4 @@ GPS_SONDA_SELECTOR = DBTSelector(
     flow_folder_name="treatment__gps_sonda",
     incremental_delay_hours=1,
     redis_key_suffix="sonda",
-    data_sources=[sonda_constants.SONDA_REGISTROS_SOURCE],
 )

--- a/queries/dbt_project.yml
+++ b/queries/dbt_project.yml
@@ -184,7 +184,7 @@ vars:
   # Tolerância de vistoria para veículos novos
   sppo_licenciamento_tolerancia_primeira_vistoria_dia: 15
   # Novo source licenciamento_stu / Infração / Agente de verão
-  data_inicio_source_veiculo: "2026-03-30"
+  data_inicio_source_veiculo: "2026-04-30"
 
   ### RDO ###
   rho_registros_sppo_staging: "rj-smtr-staging.br_rj_riodejaneiro_rdo_staging.rho_registros_sppo"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified GPS selector configurations by removing unused data-source references.

* **Chore**
  * Adjusted several data-source start dates to 2026-04-30, updating initial data fetch boundaries and project start-date configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->