### PR TITLE
[hotfix] Corrige nome do arquivo na captura do GTFS

### DIFF
--- a/pipelines/capture__gtfs/flow.py
+++ b/pipelines/capture__gtfs/flow.py
@@ -92,7 +92,7 @@ def capture__gtfs(  # noqa: PLR0915
 
         local_filepaths = [
             f"{data_root}/{{mode}}/{constants.GTFS_DATASET_ID}/{table_id}"
-            f"/{partition}/{data_versao_gtfs_final}.{{filetype}}"
+            f"/{partition}/{data_versao_gtfs_final}-00-00-00.{{filetype}}"
             for table_id in table_ids
         ]
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Notas de Lançamento

* **Chores**
  * Ajustado o formato de nomenclatura dos arquivos de dados gerados no processamento de GTFS para incluir um sufixo de timestamp padrão.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RJ-SMTR/pipelines_v3/pull/216?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->