### PR TITLE
Adiciona parâmetro timeout para capturas por API

### DIFF
--- a/pipelines/capture__rioonibus_viagem_informada/CHANGELOG.md
+++ b/pipelines/capture__rioonibus_viagem_informada/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - capture\_\_rioonibus_viagem_informada
 
+## [1.0.2] - 2026-06-12
+
+### Alterado
+
+- Aumenta timeout da API para 300s para suportar dias com alto volume de viagens (https://github.com/RJ-SMTR/pipelines_v3/pull/246)
+
 ## [1.0.1] - 2026-06-10
 
 ### Alterado

--- a/pipelines/capture__rioonibus_viagem_informada/tasks.py
+++ b/pipelines/capture__rioonibus_viagem_informada/tasks.py
@@ -46,4 +46,5 @@ def create_viagem_informada_extractor(context: SourceCaptureContext):
         url=constants.VIAGEM_INFORMADA_BASE_URL,
         params_list=params,
         raw_filepath=context.raw_filepath,
+        timeout=300,
     )

--- a/pipelines/common/capture/default_capture/CHANGELOG.md
+++ b/pipelines/common/capture/default_capture/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - default_capture
 
+## [1.0.2] - 2026-06-12
+
+### Alterado
+
+- Adiciona parâmetro `timeout` configurável em `get_api_data` e `get_raw_api_list` (https://github.com/RJ-SMTR/pipelines_v3/pull/246)
+
 ## [1.0.1] - 2026-02-24
 
 ### Alterado

--- a/pipelines/common/utils/extractors/api.py
+++ b/pipelines/common/utils/extractors/api.py
@@ -15,6 +15,7 @@ def get_api_data(
     headers: Union[None, dict] = None,
     params: Union[None, dict] = None,
     raw_filetype: str = "json",
+    timeout: Union[None, int] = constants.MAX_TIMEOUT_SECONDS,
 ) -> Union[str, dict, list[dict]]:
     """
     Get data from a single API endpoint.
@@ -24,6 +25,7 @@ def get_api_data(
         headers (Union[None, dict]): Request headers
         params (Union[None, dict]): Request parameters
         raw_filetype (str): File type for response (json, csv, etc.)
+        timeout (Union[None, int]): Request timeout in seconds. Defaults to MAX_TIMEOUT_SECONDS.
 
     Returns:
         Union[str, dict, list[dict]]: API response data
@@ -33,7 +35,7 @@ def get_api_data(
         response = requests.get(
             url,
             headers=headers,
-            timeout=constants.MAX_TIMEOUT_SECONDS,
+            timeout=timeout,
             params=params,
         )
 
@@ -90,6 +92,7 @@ def get_raw_api_list(
     raw_filepath: str,
     params_list: Union[None, list[dict]] = None,
     headers: Union[None, dict] = None,
+    timeout: Union[None, int] = constants.MAX_TIMEOUT_SECONDS,
 ) -> list[str]:
     """
     Get data from API by aggregating multiple calls and save to a local file.
@@ -99,6 +102,7 @@ def get_raw_api_list(
         raw_filepath (str): File path template with {page} placeholder
         params_list (list[dict]): List of parameter dicts for multiple requests
         headers (Union[None, dict]): Request headers
+        timeout (Union[None, int]): Request timeout in seconds. Defaults to MAX_TIMEOUT_SECONDS.
 
     Returns:
         list[str]: List with the path where data was saved
@@ -106,7 +110,9 @@ def get_raw_api_list(
     data = []
     if isinstance(url, list):
         for single_url in url:
-            page_data = get_api_data(url=single_url, headers=headers, raw_filetype="json")
+            page_data = get_api_data(
+                url=single_url, headers=headers, raw_filetype="json", timeout=timeout
+            )
             data += page_data
     else:
         if params_list is None:
@@ -116,7 +122,9 @@ def get_raw_api_list(
             )
 
         for params in params_list:
-            page_data = get_api_data(url=url, headers=headers, params=params, raw_filetype="json")
+            page_data = get_api_data(
+                url=url, headers=headers, params=params, raw_filetype="json", timeout=timeout
+            )
             data += page_data
 
     filepath = raw_filepath.format(page=0)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adicionado controle de timeout configurável para requisições de API, melhorando a estabilidade e evitando travamentos prolongados durante extrações.
  * A captura de “viagem informada” agora utiliza timeout de 300s para suportar picos de volume.

* **Documentação**
  * Atualizados changelogs para registrar a versão 1.0.2 e as mudanças relacionadas ao aumento/configuração do timeout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->