### PR TITLE
[HOTFIX] Troca data inicial para 2026-06-29

### DIFF
--- a/pipelines/capture__calendario_manual/constants.py
+++ b/pipelines/capture__calendario_manual/constants.py
@@ -24,7 +24,7 @@ CALENDARIO_MANUAL_COLUMNS = [
 
 CALENDARIO_MANUAL_SUBMIT_COLUMN = "submeter_mudancas_para_dados"
 
-CALENDARIO_MANUAL_CUTOVER_DATE = "2026-07-01"
+CALENDARIO_MANUAL_CUTOVER_DATE = "2026-06-29"
 CALENDARIO_MANUAL_PARSE_DATES = {"dia": {"format": "%d/%m/%Y", "errors": "coerce"}}
 CALENDARIO_MANUAL_FILTER_EXPR = (
     f"dia >= '{CALENDARIO_MANUAL_CUTOVER_DATE}' and {CALENDARIO_MANUAL_SUBMIT_COLUMN} == 'TRUE'"
@@ -33,7 +33,7 @@ CALENDARIO_MANUAL_FILTER_EXPR = (
 CALENDARIO_MANUAL_SOURCE = SourceTable(
     source_name=CALENDARIO_MANUAL_SOURCE_NAME,
     table_id=CALENDARIO_MANUAL_TABLE_ID,
-    first_timestamp=datetime(2026, 7, 1, 0, 0, 0, tzinfo=ZoneInfo(smtr_constants.TIMEZONE)),
+    first_timestamp=datetime(2026, 6, 29, 0, 0, 0, tzinfo=ZoneInfo(smtr_constants.TIMEZONE)),
     flow_folder_name="capture__calendario_manual",
     partition_date_only=True,
     max_recaptures=5,

--- a/queries/dbt_project.yml
+++ b/queries/dbt_project.yml
@@ -289,7 +289,7 @@ vars:
 
   ### Planejamento ###
   feed_inicial_viagem_planejada: "2024-09-29"
-  data_inicio_calendario_sheets: "2026-07-01"
+  data_inicio_calendario_sheets: "2026-06-29"
 
   ### Infraestrutura ###
   data_inicial_logs_bigquery: "2024-09-30"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ajustado o início do período de calendário para 29/06/2026, alinhando a data de corte em todo o fluxo.
  * Corrigida a referência temporal usada pelo sistema para refletir o novo marco, evitando divergências nas datas exibidas e processadas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->