### PR TITLE
Adiciona shape_id_planejado para identificar viagens circulares consecutiva

### DIFF
--- a/queries/dbt_project.yml
+++ b/queries/dbt_project.yml
@@ -176,6 +176,8 @@ vars:
   DATA_SUBSIDIO_V23_INICIO: "2026-04-16"
   # Inclui coluna shape_id_planejado para identificação das viagens circulares que possuem ida e volta consecutiva
   DATA_SUBSIDIO_V24_INICIO: "2026-05-16"
+  # Inclui shape_id_planejado no join no modelo `aux_viagem_circular.sql` para identificar viagens circulares que possuem ida e volta consecutiva
+  DATA_SUBSIDIO_V25_INICIO: "2026-06-16"
   # Placeholder feature
   DATA_SUBSIDIO_V99_INICIO: "3000-01-01"
 

--- a/queries/dbt_project.yml
+++ b/queries/dbt_project.yml
@@ -176,8 +176,6 @@ vars:
   DATA_SUBSIDIO_V23_INICIO: "2026-04-16"
   # Inclui coluna shape_id_planejado para identificação das viagens circulares que possuem ida e volta consecutiva
   DATA_SUBSIDIO_V24_INICIO: "2026-05-16"
-  # Inclui shape_id_planejado no join no modelo `aux_viagem_circular.sql` para identificar viagens circulares que possuem ida e volta consecutiva
-  DATA_SUBSIDIO_V25_INICIO: "2026-06-16"
   # Placeholder feature
   DATA_SUBSIDIO_V99_INICIO: "3000-01-01"
 

--- a/queries/models/projeto_subsidio_sppo/CHANGELOG.md
+++ b/queries/models/projeto_subsidio_sppo/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - projeto_subsidio_sppo
 
+## [9.4.0] - 2026-07-06
+
+### Adicionado
+
+- Adiciona campo `shape_id_planejado` no join para identificar viagens circulares consecutivas no modelo `aux_viagem_circular`. (https://github.com/RJ-SMTR/pipelines_v3/pull/349)
+
 ## [9.3.9] - 2026-06-11
 
 ### Adicionado

--- a/queries/models/projeto_subsidio_sppo/aux_viagem_circular.sql
+++ b/queries/models/projeto_subsidio_sppo/aux_viagem_circular.sql
@@ -38,8 +38,8 @@ with
                     on c.id_veiculo = v.id_veiculo
                     and c.servico_realizado = v.servico_realizado
                     and c.sentido = v.sentido
-                    {% if var("run_date") >= var("DATA_SUBSIDIO_V25_INICIO")%}
-                    and c.shape_id_planejado = v.shape_id_planejado
+                    {% if var("run_date") >= var("DATA_SUBSIDIO_V25_INICIO") %}
+                        and c.shape_id_planejado = v.shape_id_planejado
                     {% endif %}
             ) v
         where id_viagem is not null

--- a/queries/models/projeto_subsidio_sppo/aux_viagem_circular.sql
+++ b/queries/models/projeto_subsidio_sppo/aux_viagem_circular.sql
@@ -4,7 +4,7 @@ with
     ida_volta_circular as (
         select t.*
 
-                from {{ ref("aux_ida_volta_circular") }} t
+        from {{ ref("aux_ida_volta_circular") }} t
         where
             flag_proximo_volta = true
             and sentido_shape = "I"
@@ -37,7 +37,10 @@ with
                     ida_volta_circular c
                     on c.id_veiculo = v.id_veiculo
                     and c.servico_realizado = v.servico_realizado
-                    and c.sentido = v.sentido
+                    and c.sentido = v.sentido 
+                    {% if var("run_date") >= var("DATA_SUBSIDIO_V25_INICIO")%}
+                    and c.shape_id_planejado = v.shape_id_planejado
+                    {% endif %}
             ) v
         where id_viagem is not null
     )

--- a/queries/models/projeto_subsidio_sppo/aux_viagem_circular.sql
+++ b/queries/models/projeto_subsidio_sppo/aux_viagem_circular.sql
@@ -37,7 +37,7 @@ with
                     ida_volta_circular c
                     on c.id_veiculo = v.id_veiculo
                     and c.servico_realizado = v.servico_realizado
-                    and c.sentido = v.sentido 
+                    and c.sentido = v.sentido
                     {% if var("run_date") >= var("DATA_SUBSIDIO_V25_INICIO")%}
                     and c.shape_id_planejado = v.shape_id_planejado
                     {% endif %}

--- a/queries/models/projeto_subsidio_sppo/aux_viagem_circular.sql
+++ b/queries/models/projeto_subsidio_sppo/aux_viagem_circular.sql
@@ -38,7 +38,7 @@ with
                     on c.id_veiculo = v.id_veiculo
                     and c.servico_realizado = v.servico_realizado
                     and c.sentido = v.sentido
-                    {% if var("run_date") >= var("DATA_SUBSIDIO_V25_INICIO") %}
+                    {% if var("run_date") >= var("DATA_SUBSIDIO_V24_INICIO") %}
                         and c.shape_id_planejado = v.shape_id_planejado
                     {% endif %}
             ) v


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Melhorias**
  * O processamento de viagens circulares agora considera um critério adicional de correspondência quando a data de execução está a partir da nova regra aplicada.
  * Isso melhora a consistência na identificação de sequências de viagens em cenários específicos.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->