### PR TITLE
Adiciona numero_identificacao nos modelos de guardador de veículo

### DIFF
--- a/pipelines/common/treatment/default_treatment/tasks.py
+++ b/pipelines/common/treatment/default_treatment/tasks.py
@@ -219,13 +219,14 @@ def run_dbt_snapshots(
         contexts (list[DBTSelectorMaterializationContext]): Lista de contextos de materialização.
         flags (Optional[list[str]]): Flags adicionais para execução do dbt.
     """
+    snapshot_flags = [flag for flag in (flags or []) if flag not in {"--empty", "--full-refresh"}]
     for context in contexts:
         if context.snapshot_selector is None:
             continue
         run_dbt(
             dbt_obj=context.snapshot_selector,
             dbt_vars=context.dbt_vars,
-            flags=flags,
+            flags=snapshot_flags,
             is_snapshot=True,
             env=context.env,
         )

--- a/pipelines/treatment__riorotativo/constants.py
+++ b/pipelines/treatment__riorotativo/constants.py
@@ -16,7 +16,12 @@ from pipelines.common.treatment.default_treatment.utils import DBTSelector, DBTT
 RIOROTATIVO_DIARIO_CHECKS_LIST = {
     "guardador_veiculo_riorotativo": {
         "not_null": {"description": "Todos os valores da coluna `{column_name}` não nulos"},
-        "unique": {"description": "Todos os números de identificação são únicos"},
+        "dbt_utils.unique_combination_of_columns__documento_cnpj__guardador_veiculo_riorotativo": {
+            "description": "Cada combinação de documento e CNPJ é única"
+        },
+        "dbt_utils.unique_combination_of_columns__cnpj_numero_identificacao__guardador_veiculo_riorotativo": {
+            "description": "Cada combinação de CNPJ e número de identificação é única"
+        },
     },
     "guardador_veiculo_riorotativo_historico": {
         "not_null": {"description": "Todos os valores da coluna `{column_name}` não nulos"},

--- a/pipelines/treatment__riorotativo/constants.py
+++ b/pipelines/treatment__riorotativo/constants.py
@@ -16,6 +16,7 @@ from pipelines.common.treatment.default_treatment.utils import DBTSelector, DBTT
 RIOROTATIVO_DIARIO_CHECKS_LIST = {
     "guardador_veiculo_riorotativo": {
         "not_null": {"description": "Todos os valores da coluna `{column_name}` não nulos"},
+        "unique": {"description": "Todos os números de identificação são únicos"},
     },
     "guardador_veiculo_riorotativo_historico": {
         "not_null": {"description": "Todos os valores da coluna `{column_name}` não nulos"},

--- a/queries/models/docs.md
+++ b/queries/models/docs.md
@@ -1745,6 +1745,10 @@ Data de fim do período informado para o cadastro do Rio Rotativo Digital
 Tipo do documento do guardador de veículo
 {% enddocs %}
 
+{% docs numero_identificacao_guardador_veiculo_riorotativo %}
+Número de identificação do guardador de veículo
+{% enddocs %}
+
 {% docs tipo_documento_agente_verificacao_riorotativo %}
 Tipo do documento do agente de verificação
 {% enddocs %}

--- a/queries/models/riorotativo/CHANGELOG.md
+++ b/queries/models/riorotativo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog - riorotativo
 
+## [1.1.0] - 2026-07-16
+
+### Adicionado
+
+- Adiciona `numero_identificacao` aos modelos de guardadores de veículo, normalizado
+  com quatro dígitos, e teste de unicidade (https://github.com/RJ-SMTR/pipelines_v3/pull/384)
+
 ## [1.0.1] - 2026-07-15
 
 ### Alterado

--- a/queries/models/riorotativo/guardador_veiculo_riorotativo.sql
+++ b/queries/models/riorotativo/guardador_veiculo_riorotativo.sql
@@ -23,6 +23,7 @@ select
     telefone,
     documento,
     tipo_documento,
+    numero_identificacao,
     cnpj,
     razao_social,
     nome_fantasia,

--- a/queries/models/riorotativo/guardador_veiculo_riorotativo_historico.sql
+++ b/queries/models/riorotativo/guardador_veiculo_riorotativo_historico.sql
@@ -63,7 +63,7 @@
 
 with
     credenciados as (
-        select data, documento, tipo_documento, cnpj
+        select data, documento, tipo_documento, numero_identificacao, cnpj
         from {{ ref("staging_guardador_veiculo_riorotativo") }}
         {% if is_incremental() %} where {{ incremental_filter }} {% endif %}
     ),
@@ -111,6 +111,7 @@ with
             c.cnpj,
             c.documento,
             c.tipo_documento,
+            c.numero_identificacao,
             if(b.documento is not null, "bloqueado", "ativo") as status,
             b.motivo_bloqueio,
             b.decisao_bloqueio
@@ -148,6 +149,7 @@ with
             s.cnpj,
             s.documento,
             s.tipo_documento,
+            s.numero_identificacao,
             c.id_cliente,
             c.nome,
             c.email,

--- a/queries/models/riorotativo/schema.yml
+++ b/queries/models/riorotativo/schema.yml
@@ -31,6 +31,15 @@ models:
         description: "{{ doc('tipo_documento_guardador_veiculo_riorotativo') }}"
         data_type: string
         quote: true
+      - name: numero_identificacao
+        description: "{{ doc('numero_identificacao_guardador_veiculo_riorotativo') }}"
+        data_type: string
+        quote: true
+        tests:
+          - unique:
+              name: unique__numero_identificacao__guardador_veiculo_riorotativo
+              config:
+                where: "1=1"
       - name: id_cliente
         description: "{{ doc('id_cliente') }}"
         data_type: string
@@ -109,6 +118,10 @@ models:
         quote: true
       - name: cnpj
         description: "{{ doc('cnpj_entidade_credenciadora_riorotativo') }}"
+        data_type: string
+        quote: true
+      - name: numero_identificacao
+        description: "{{ doc('numero_identificacao_guardador_veiculo_riorotativo') }}"
         data_type: string
         quote: true
       - name: documento

--- a/queries/models/riorotativo/schema.yml
+++ b/queries/models/riorotativo/schema.yml
@@ -9,6 +9,23 @@ models:
       Fonte: última partição de guardador_veiculo_riorotativo_historico dentro da janela.
       Guardador de veículo ausente da última captura é considerado removido; guardadores de veículo bloqueados são excluídos —
       para status e histórico use guardador_veiculo_riorotativo_historico.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          name: dbt_utils.unique_combination_of_columns__documento_cnpj__guardador_veiculo_riorotativo
+          config:
+            where: "1=1"
+          arguments:
+            combination_of_columns:
+              - documento
+              - cnpj
+      - dbt_utils.unique_combination_of_columns:
+          name: dbt_utils.unique_combination_of_columns__cnpj_numero_identificacao__guardador_veiculo_riorotativo
+          config:
+            where: "1=1"
+          arguments:
+            combination_of_columns:
+              - cnpj
+              - numero_identificacao
     columns:
       - name: documento
         description: "{{ doc('documento_cliente') }} [protegido]"
@@ -35,11 +52,6 @@ models:
         description: "{{ doc('numero_identificacao_guardador_veiculo_riorotativo') }}"
         data_type: string
         quote: true
-        tests:
-          - unique:
-              name: unique__numero_identificacao__guardador_veiculo_riorotativo
-              config:
-                where: "1=1"
       - name: id_cliente
         description: "{{ doc('id_cliente') }}"
         data_type: string

--- a/queries/models/riorotativo/staging/schema.yml
+++ b/queries/models/riorotativo/staging/schema.yml
@@ -30,6 +30,10 @@ models:
         description: "{{ doc('tipo_documento_guardador_veiculo_riorotativo') }}"
         data_type: string
         quote: true
+      - name: numero_identificacao
+        description: "{{ doc('numero_identificacao_guardador_veiculo_riorotativo') }}"
+        data_type: string
+        quote: true
       - name: cnpj
         description: "{{ doc('cnpj_entidade_credenciadora_riorotativo') }}"
         data_type: string

--- a/queries/models/riorotativo/staging/staging_guardador_veiculo_riorotativo.sql
+++ b/queries/models/riorotativo/staging/staging_guardador_veiculo_riorotativo.sql
@@ -11,6 +11,9 @@ with
         {% for entidade in entidades %}
             select
                 data,
+                lpad(
+                    safe_cast(identificacao as string), 4, '0'
+                ) as numero_identificacao,
                 lpad(safe_cast(cpf as string), 11, '0') as documento,
                 "CPF" as tipo_documento,
                 "{{ entidade.cnpj }}" as cnpj,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Novos Recursos**
  * Adicionado o número de identificação do guardador de veículo aos dados de staging, histórico e consulta final.
  * O identificador agora é padronizado com quatro dígitos, preenchendo zeros à esquerda quando necessário.
  * Incluída documentação para o novo campo.

* **Validações**
  * Adicionado teste para garantir a unicidade dos números de identificação.

* **Correções**
  * Execuções de snapshots agora ignoram opções incompatíveis de atualização e processamento vazio, evitando comportamentos inesperados.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->