### PR TITLE
Aumenta timeout do capture__serpro_autuacao para 5h

### DIFF
--- a/pipelines/capture__serpro_autuacao/CHANGELOG.md
+++ b/pipelines/capture__serpro_autuacao/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - capture__serpro_autuacao
 
+## [1.1.1] - 2026-07-20
+
+### Alterado
+
+- Define `timeout_seconds=18000` (5h) no flow
+
 ## [1.1.0] - 2026-06-11
 
 ### Alterado

--- a/pipelines/capture__serpro_autuacao/CHANGELOG.md
+++ b/pipelines/capture__serpro_autuacao/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Alterado
 
-- Define `timeout_seconds=18000` (5h) no flow
+- Define `timeout_seconds=18000` (5h) no flow (https://github.com/RJ-SMTR/pipelines_v3/pull/394)
 
 ## [1.1.0] - 2026-06-11
 

--- a/pipelines/capture__serpro_autuacao/flow.py
+++ b/pipelines/capture__serpro_autuacao/flow.py
@@ -16,7 +16,7 @@ from pipelines.common.capture.default_capture.utils import rename_capture_flow_r
 from pipelines.common.utils.prefect import flow
 
 
-@flow(log_prints=True, flow_run_name=rename_capture_flow_run, timeout_seconds=10800)
+@flow(log_prints=True, flow_run_name=rename_capture_flow_run, timeout_seconds=18000)
 def capture__serpro_autuacao(
     env: Optional[str] = None,
     timestamp: Optional[str] = None,


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Alterações**
  * Aumentado para 5 horas o tempo máximo permitido para execução do fluxo de captura de autuações.
  * Atualizado o changelog com a nova versão 1.1.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->