### PR TITLE
Atualiza tabela de exceção

### DIFF
--- a/queries/models/dashboard_subsidio_sppo/CHANGELOG.md
+++ b/queries/models/dashboard_subsidio_sppo/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - dashboard_subsidio_sppo
 
+## [8.2.6] - 2026-07-21
+
+### Alterado
+
+- Alterado o modelo `aux_viagem_remunerada_excecao` para adicionar uma exceção para o limite de viagens de servicos especificados no Processo nº SEI_000301.010399_2026_90. (https://github.com/RJ-SMTR/pipelines_v3/pull/405)
+
 ## [8.2.5] - 2026-07-09
 
 ### Alterado

--- a/queries/models/dashboard_subsidio_sppo/staging/aux_viagem_remunerada_excecao.sql
+++ b/queries/models/dashboard_subsidio_sppo/staging/aux_viagem_remunerada_excecao.sql
@@ -19,6 +19,22 @@ with
                         cast([] as array<string>) as servicos,
                         true as indicador_viagem_dentro_limite
                     ),
+                    struct(  -- Processo 000399.016030/2026-59:
+                        '2026-06-13' as data_inicio,
+                        '2026-06-13' as data_fim,
+                        '2026-06-13T15:00:00' as faixa_horaria_inicio,
+                        '2026-06-13T17:59:59' as faixa_horaria_fim,
+                        cast([] as array<string>) as servicos,
+                        true as indicador_viagem_dentro_limite
+                    ),
+                    struct(  -- Processo 000399.016030/2026-59:
+                        '2026-06-13' as data_inicio,
+                        '2026-06-13' as data_fim,
+                        '2026-06-13T18:00:00' as faixa_horaria_inicio,
+                        '2026-06-13T20:59:59' as faixa_horaria_fim,
+                        cast([] as array<string>) as servicos,
+                        true as indicador_viagem_dentro_limite
+                    ),
                     struct(  -- Processo 000399.016030/2026-59
                         '2026-06-19' as data_inicio,
                         '2026-06-19' as data_fim,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Correções**
  * Atualizados os dados de exceção para incluir o período de 13/06/2026.
  * Adicionadas as faixas horárias das 15h às 17h59 e das 18h às 20h59, mantendo o indicador de viagem dentro do limite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->