### PR TITLE
Retificação maio Q1 2026

### DIFF
--- a/queries/models/dashboard_subsidio_sppo/CHANGELOG.md
+++ b/queries/models/dashboard_subsidio_sppo/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - dashboard_subsidio_sppo
 
+## [8.2.6] - 2026-07-23
+
+### Alterado
+
+- Alterado o modelo `aux_viagem_remunerada_excecao` para retificar a quinzena de `2026-05-01` a `2026-05-15`: inclui o serviço `LECD137` e remove o `LECD135`, conforme Processo SEI_000301.012216_2026_71 (https://github.com/RJ-SMTR/pipelines_v3/pull/420)
+
 ## [8.2.5] - 2026-07-09
 
 ### Alterado

--- a/queries/models/dashboard_subsidio_sppo/staging/aux_viagem_remunerada_excecao.sql
+++ b/queries/models/dashboard_subsidio_sppo/staging/aux_viagem_remunerada_excecao.sql
@@ -247,8 +247,8 @@ with
                             "LECD132",
                             "LECD133",
                             "LECD134",
-                            "LECD135",
                             "LECD136",
+                            "LECD137", -- Retificação Processo SEI_000301.012216_2026_71
                             "LECD138"
                         ] as servicos,
                         true as indicador_viagem_dentro_limite


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Correções**
  * Corrigida a quinzena de 01/05/2026 a 15/05/2026 no modelo de exceções de viagens remuneradas.
  * Atualizado o serviço considerado, substituindo **LECD135** por **LECD137**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->