### PR TITLE
[FIX] fixa o Python do pre-commit.ci na versão 3.13

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,8 @@
+# Pin to 3.13: pre-commit.ci defaults to the newest available Python (3.14),
+# but dbt-checkpoint → mixpanel → pydantic<2.12 cannot build on 3.14 yet.
+default_language_version:
+  python: python3.13
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Fixada explicitamente a versão do Python usada pelas verificações automáticas em Python 3.13.
  * Adicionados comentários para documentar essa configuração e evitar atualizações automáticas inesperadas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->