### PR TITLE
[HOT-FIX] teste da viagem completa sem o d+1

### DIFF
--- a/queries/models/projeto_subsidio_sppo/schema.yml
+++ b/queries/models/projeto_subsidio_sppo/schema.yml
@@ -744,7 +744,7 @@ models:
             partition_by: id_veiculo
             gaps: allowed
           config:
-            where: "data between date_sub(date('{{ var('start_date') }}'), interval 1 day) and date('{{ var('end_date') }}')"
+            where: "data between date('{{ var('date_range_start') }}') and date('{{ var('date_range_end') }}')"
     columns:
       - name: consorcio
         description: "{{ doc('consorcio') }}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Testes**
  * Atualizado o filtro temporal do teste de intervalos mutuamente exclusivos para usar diretamente as datas de início e fim definidas.
  * Corrigida a validação do modelo de viagens completas para refletir o período correto.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->