### PR TITLE
Corrige lógica das partidas no GTFS

### DIFF
--- a/queries/models/planejamento/CHANGELOG.md
+++ b/queries/models/planejamento/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - planejamento
 
+## [1.8.5] - 2026-08-14
+
+### Corrigido
+
+- Ajusta os modelos `viagem_planejada_planejamento` e `viagem_planejada_planejamento_dia` para processar somente o feed atual e manter partidas com horários iguais ou superiores a 24:00:00 associadas ao mesmo dia operacional, normalizando `horario_partida` com módulo 24 (https://github.com/RJ-SMTR/pipelines_v3/pull/516)
+
 ## [1.8.4] - 2026-07-31
 
 ### Corrigido

--- a/queries/models/planejamento/viagem_planejada_planejamento.sql
+++ b/queries/models/planejamento/viagem_planejada_planejamento.sql
@@ -10,7 +10,6 @@
     )
 }}
 
--- depends_on: {{ ref('feed_info_gtfs') }}
 {% if execute and is_incremental() %}
     {% set columns = (
         list_columns()
@@ -32,11 +31,8 @@
             )
         )
     {% endset %}
-    {% set last_feed_version = get_last_feed_start_date(var("data_versao_gtfs")) %}
     {% set feed_filter %}
-        feed_start_date in (
-            date('{{ last_feed_version }}'), date('{{ var("data_versao_gtfs") }}')
-        )
+        feed_start_date = date('{{ var("data_versao_gtfs") }}')
     {% endset %}
 {% else %}
     {% set sha_column %}
@@ -176,13 +172,14 @@ with
     ),
     /*
     Monta a base da viagem planejada: converte partida_seconds em horário
-    HH:MM:SS, deriva tipo_dia do service_id (Útil/Sábado/Domingo) e o sentido
-    (C = circular, I = ida quando direction_id 0, V = volta caso contrário).
+    HH:MM:SS normalizado com módulo 24, deriva tipo_dia do service_id
+    (Útil/Sábado/Domingo) e o sentido (C = circular, I = ida quando
+    direction_id 0, V = volta caso contrário).
     */
     viagem_planejada_base as (
         select
             concat(
-                lpad(cast(div(partida_seconds, 3600) as string), 2, '0'),
+                lpad(cast(mod(div(partida_seconds, 3600), 24) as string), 2, '0'),
                 ':',
                 lpad(cast(mod(div(partida_seconds, 60), 60) as string), 2, '0'),
                 ':',

--- a/queries/models/planejamento/viagem_planejada_planejamento_dia.sql
+++ b/queries/models/planejamento/viagem_planejada_planejamento_dia.sql
@@ -22,7 +22,7 @@
 
 {% set source_filter %}
     data between
-        date_sub(date('{{ var("date_range_start") }}'), interval 1 day)
+        date('{{ var("date_range_start") }}')
         and {{ date_range_end_extended }}
 {% endset %}
 
@@ -101,19 +101,7 @@ with
     ),
     viagem_dia as (
         select
-            date(
-                datetime(
-                    timestamp(
-                        c.data + make_interval(
-                            hour => cast(split(vp.horario_partida, ':')[0] as int64),
-                            minute => cast(split(vp.horario_partida, ':')[1] as int64),
-                            second => cast(split(vp.horario_partida, ':')[2] as int64)
-                        ),
-                        "America/Sao_Paulo"
-                    ),
-                    "America/Sao_Paulo"
-                )
-            ) as data,
+            c.data as data,
             datetime(
                 timestamp(
                     c.data + make_interval(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Correções**
  * Corrigido o processamento de viagens planejadas para considerar apenas os dados do feed atual.
  * Partidas com horários iguais ou superiores a 24:00:00 permanecem associadas ao mesmo dia operacional.
  * Horários de partida agora são normalizados corretamente no formato `HH:MM:SS`.
  * Corrigida a identificação da data da viagem, evitando ajustes indevidos baseados no horário e no fuso horário.

* **Versão**
  * Disponibilizada a versão 1.8.5 em 14/08/2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->