### PR TITLE
Ajusta captura e desempate de viagens informadas da Rio Ônibus

### DIFF
--- a/pipelines/capture__rioonibus_viagem_informada/tasks.py
+++ b/pipelines/capture__rioonibus_viagem_informada/tasks.py
@@ -27,7 +27,7 @@ def create_viagem_informada_extractor(context: SourceCaptureContext):
     """
 
     end_date = context.timestamp.date()
-    start_date = end_date - timedelta(days=2)
+    start_date = end_date - timedelta(days=1)
 
     credentials = get_env_secret(constants.RIO_ONIBUS_SECRET_PATH)
     api_key = credentials["guididentificacao"]

--- a/queries/models/monitoramento/viagem_informada_monitoramento.sql
+++ b/queries/models/monitoramento/viagem_informada_monitoramento.sql
@@ -180,17 +180,14 @@ with
         {% endif %}
     ),
     deduplicado as (
-        select * except (rn, priority)
-        from
-            (
-                select
-                    *,
-                    row_number() over (
-                        partition by id_viagem order by datetime_captura desc, priority
-                    ) as rn
-                from complete_partitions
+        select * except (priority)
+        from complete_partitions
+        qualify
+            row_number() over (
+                partition by id_viagem
+                order by datetime_captura desc, datetime_processamento desc, priority
             )
-        where rn = 1
+            = 1
     ),
     calendario as (
         select *


### PR DESCRIPTION
## Resumo

- Ajusta o início da captura da Rio Ônibus de D-2 para D-1.
- Altera a CTE `deduplicado` para usar `QUALIFY`.
- Usa o maior `datetime_processamento` após o maior `datetime_captura` como critério de desempate.

## Validações

- Ruff e formatação Python.
- `sqlfmt` no modelo SQL.
- `git diff --check`.
- Teste funcional da janela de captura.
- Hooks de pre-commit passaram no commit.

O parse/compile/show completo do dbt continua limitado por erros globais preexistentes do projeto no dbt Fusion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Correções**
  * Ajustado o período inicial da captura de viagens informadas para considerar o dia anterior ao timestamp.
  * Aprimorada a deduplicação dos registros, priorizando captura, processamento e prioridade para manter a informação mais relevante por viagem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->