### PR TITLE
Ingestão do OpenMetadata como padrão

### DIFF
--- a/pipelines/capture__gtfs/CHANGELOG.md
+++ b/pipelines/capture__gtfs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - capture__gtfs
 
+## [1.4.0] - 2026-08-27
+
+### Adicionado
+
+- Adiciona a ingestão dos artefatos dbt no OpenMetadata após a materialização e os testes do GTFS (https://github.com/RJ-SMTR/pipelines_v3/pull/579)
+
 ## [1.3.1] - 2026-08-26
 
 ### Adicionado

--- a/pipelines/capture__gtfs/Dockerfile
+++ b/pipelines/capture__gtfs/Dockerfile
@@ -13,4 +13,16 @@ COPY ./pipelines/treatment__planejamento_diario ./pipelines/treatment__planejame
 COPY ./pipelines/common/ ./pipelines/common/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/capture__gtfs/flow.py
+++ b/pipelines/capture__gtfs/flow.py
@@ -36,6 +36,7 @@ from pipelines.common.tasks import (
 )
 from pipelines.common.treatment.default_quality_check.tasks import task_dbt_test_notify_discord
 from pipelines.common.treatment.default_treatment.tasks import (
+    ingest_dbt_artifacts_to_openmetadata,
     install_dbt_packages,
     setup_dbt_queries,
 )
@@ -184,6 +185,12 @@ async def capture__gtfs(  # noqa: PLR0913, PLR0915
             test_descriptions=constants.GTFS_DATA_CHECKS_LIST,
         )
         dbt_logs = run_dbt_tests_gtfs(data_versao_gtfs=data_versao_gtfs_final, env=env, flags=flags)
+        ingest_dbt_artifacts_to_openmetadata(
+            env=env,
+            deployment_name=deployment_name,
+            flow_run_id=runtime.flow_run.id,
+            wait_for=[dbt_logs],
+        )
         task_dbt_test_notify_discord(
             dbt_test=dbt_test,
             dbt_vars={"data_versao_gtfs": data_versao_gtfs_final},

--- a/pipelines/common/treatment/default_quality_check/CHANGELOG.md
+++ b/pipelines/common/treatment/default_quality_check/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - default_quality_check
 
+## [1.2.0] - 2026-08-27
+
+### Adicionado
+
+- Adiciona a ingestão dos artefatos dbt no OpenMetadata após a execução dos testes de qualidade (https://github.com/RJ-SMTR/pipelines_v3/pull/579)
+
 ## [1.1.1] - 2026-06-23
 
 ### Alterado

--- a/pipelines/common/treatment/default_quality_check/flow.py
+++ b/pipelines/common/treatment/default_quality_check/flow.py
@@ -18,6 +18,7 @@ from pipelines.common.treatment.default_quality_check.tasks import (
     task_run_dbt_tests,
 )
 from pipelines.common.treatment.default_treatment.tasks import (
+    ingest_dbt_artifacts_to_openmetadata,
     install_dbt_packages,
     setup_dbt_queries,
 )
@@ -115,6 +116,13 @@ def create_quality_check_flows_default_tasks(  # noqa: PLR0913
             tasks["install_dbt_packages"],
             *tasks_wait_for.get("run_dbt_tests", []),
         ],
+    )
+
+    tasks["ingest_openmetadata"] = ingest_dbt_artifacts_to_openmetadata(
+        env=tasks["env"],
+        deployment_name=deployment_name,
+        flow_run_id=runtime.flow_run.id,
+        wait_for=[tasks["run_dbt_tests"]],
     )
 
     tasks["notify_discord"] = task_dbt_test_notify_discord(

--- a/pipelines/common/treatment/default_treatment/CHANGELOG.md
+++ b/pipelines/common/treatment/default_treatment/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - default_treatment
 
+## [1.5.0] - 2026-08-27
+
+### Alterado
+
+- Habilita por padrão a ingestão dos artefatos dbt no OpenMetadata nos flows genéricos de materialização (https://github.com/RJ-SMTR/pipelines_v3/pull/579)
+
 ## [1.4.1] - 2026-07-29
 
 ### Corrigido

--- a/pipelines/common/treatment/default_treatment/flow.py
+++ b/pipelines/common/treatment/default_treatment/flow.py
@@ -44,7 +44,7 @@ def create_materialization_flows_default_tasks(  # noqa: PLR0913
     fallback_run: bool = False,
     skip_pre_test: bool = False,
     test_only: bool = False,
-    ingest_openmetadata: bool = False,
+    ingest_openmetadata: bool = True,
     save_redis: Optional[bool] = True,
 ):
     """

--- a/pipelines/control__model_freshness/CHANGELOG.md
+++ b/pipelines/control__model_freshness/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.2.0] - 2026-08-27
+
+### Adicionado
+
+- Adiciona a ingestão dos artefatos dbt no OpenMetadata após os testes de freshness dos modelos (https://github.com/RJ-SMTR/pipelines_v3/pull/579)
+
 ## [1.1.5] - 2026-08-17
 
 ### Adicionado

--- a/pipelines/control__model_freshness/Dockerfile
+++ b/pipelines/control__model_freshness/Dockerfile
@@ -11,4 +11,16 @@ COPY ./pipelines/control__model_freshness ./pipelines/control__model_freshness/
 COPY ./pipelines/common/ ./pipelines/common/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/control__model_freshness/flow.py
+++ b/pipelines/control__model_freshness/flow.py
@@ -20,6 +20,7 @@ from pipelines.common.tasks import (
     setup_environment,
 )
 from pipelines.common.treatment.default_treatment.tasks import (
+    ingest_dbt_artifacts_to_openmetadata,
     install_dbt_packages,
     setup_dbt_queries,
 )
@@ -65,6 +66,12 @@ def control__model_freshness(env: Optional[str] = None, test_select: str = "tag:
         datetime_start=timestamp - lookback,
         datetime_end=timestamp,
         env=env,
+    )
+
+    ingest_dbt_artifacts_to_openmetadata(
+        env=env,
+        deployment_name=runtime.deployment.name,
+        flow_run_id=runtime.flow_run.id,
     )
 
     has_issues, failed_results = parse_model_freshness_output(dbt_output=dbt_logs)

--- a/pipelines/control__source_freshness/CHANGELOG.md
+++ b/pipelines/control__source_freshness/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.2.0] - 2026-08-27
+
+### Adicionado
+
+- Adiciona a ingestão dos artefatos dbt no OpenMetadata após a execução do freshness das fontes (https://github.com/RJ-SMTR/pipelines_v3/pull/579)
+
 ## [1.1.2] - 2026-06-23
 
 ### Alterado

--- a/pipelines/control__source_freshness/Dockerfile
+++ b/pipelines/control__source_freshness/Dockerfile
@@ -11,4 +11,16 @@ COPY ./pipelines/control__source_freshness ./pipelines/control__source_freshness
 COPY ./pipelines/common/ ./pipelines/common/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/control__source_freshness/flow.py
+++ b/pipelines/control__source_freshness/flow.py
@@ -15,6 +15,7 @@ from prefect import runtime
 
 from pipelines.common.tasks import get_run_env, initialize_sentry, setup_environment
 from pipelines.common.treatment.default_treatment.tasks import (
+    ingest_dbt_artifacts_to_openmetadata,
     install_dbt_packages,
     setup_dbt_queries,
 )
@@ -49,6 +50,13 @@ def control__source_freshness(env: Optional[str] = None, flags: Optional[list[st
     dbt_deps = install_dbt_packages(wait_for=[queries])
 
     dbt_output = run_source_freshness(flags=flags, env=env, wait_for=[dbt_deps])
+
+    ingest_dbt_artifacts_to_openmetadata(
+        env=env,
+        deployment_name=runtime.deployment.name,
+        flow_run_id=runtime.flow_run.id,
+        wait_for=[dbt_output],
+    )
 
     has_issues, failed_sources = parse_source_freshness_output(dbt_output=dbt_output)
 

--- a/pipelines/integration__previnity_negativacao/CHANGELOG.md
+++ b/pipelines/integration__previnity_negativacao/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - integration__previnity_negativacao
 
+## [1.3.0] - 2026-08-27
+
+### Adicionado
+
+- Adiciona a ingestão dos artefatos dbt no OpenMetadata após a materialização e os testes da integração (https://github.com/RJ-SMTR/pipelines_v3/pull/579)
+
 ## [1.2.1] - 2026-06-23
 
 ### Alterado

--- a/pipelines/integration__previnity_negativacao/Dockerfile
+++ b/pipelines/integration__previnity_negativacao/Dockerfile
@@ -15,4 +15,16 @@ COPY ./pipelines/capture__serpro_autuacao ./pipelines/capture__serpro_autuacao/
 COPY ./pipelines/common/ ./pipelines/common/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/integration__previnity_negativacao/flow.py
+++ b/pipelines/integration__previnity_negativacao/flow.py
@@ -32,6 +32,7 @@ from pipelines.common.tasks import (
 )
 from pipelines.common.treatment.default_treatment.tasks import (
     create_materialization_contexts,
+    ingest_dbt_artifacts_to_openmetadata,
     install_dbt_packages,
     run_dbt_selector_tests,
     run_dbt_selectors,
@@ -154,6 +155,13 @@ async def integration__previnity_negativacao(  # noqa: PLR0913
             contexts=materialization_contexts,
             mode="post",
             wait_for=[run_dbt_future],
+        )
+
+        ingest_dbt_artifacts_to_openmetadata(
+            env=env,
+            deployment_name=runtime.deployment.name,
+            flow_run_id=runtime.flow_run.id,
+            wait_for=[run_tests_future],
         )
 
         task_dbt_selector_test_notify_discord.map(

--- a/pipelines/integration__upload_transacao_cct/CHANGELOG.md
+++ b/pipelines/integration__upload_transacao_cct/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - integration__upload_transacao_cct
 
+## [1.2.0] - 2026-08-27
+
+### Adicionado
+
+- Adiciona a ingestão dos artefatos dbt no OpenMetadata após a materialização e os testes da integração (https://github.com/RJ-SMTR/pipelines_v3/pull/579)
+
 ## [1.1.1] - 2026-06-23
 
 ### Alterado

--- a/pipelines/integration__upload_transacao_cct/Dockerfile
+++ b/pipelines/integration__upload_transacao_cct/Dockerfile
@@ -14,4 +14,16 @@ COPY ./pipelines/integration__upload_transacao_cct ./pipelines/integration__uplo
 COPY ./pipelines/common/ ./pipelines/common/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/integration__upload_transacao_cct/flow.py
+++ b/pipelines/integration__upload_transacao_cct/flow.py
@@ -10,6 +10,7 @@ from pipelines.common.tasks import (
     setup_environment,
 )
 from pipelines.common.treatment.default_treatment.tasks import (
+    ingest_dbt_artifacts_to_openmetadata,
     install_dbt_packages,
     run_dbt_selector_tests,
     run_dbt_selectors,
@@ -108,6 +109,13 @@ def integration__upload_transacao_cct(  # noqa: PLR0913
         contexts=contexts,
         mode="post",
         wait_for=[run_sincronizacao_model],
+    )
+
+    ingest_dbt_artifacts_to_openmetadata(
+        env=env,
+        deployment_name=runtime.deployment.name,
+        flow_run_id=runtime.flow_run.id,
+        wait_for=[run_sincronizacao_test],
     )
 
     notify_discord = task_dbt_selector_test_notify_discord(

--- a/pipelines/quality_check__ordem_pagamento/CHANGELOG.md
+++ b/pipelines/quality_check__ordem_pagamento/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - quality_check__ordem_pagamento
 
+## [1.1.0] - 2026-08-27
+
+### Adicionado
+
+- Adiciona a ingestão dos artefatos dbt no OpenMetadata após os testes de qualidade (https://github.com/RJ-SMTR/pipelines_v3/pull/579)
+
 ## [1.0.1] - 2026-08-13
 
 ### Corrigido

--- a/pipelines/quality_check__ordem_pagamento/Dockerfile
+++ b/pipelines/quality_check__ordem_pagamento/Dockerfile
@@ -11,4 +11,16 @@ COPY ./pipelines/quality_check__ordem_pagamento ./pipelines/quality_check__ordem
 COPY ./pipelines/common/ ./pipelines/common/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__cadastro/Dockerfile
+++ b/pipelines/treatment__cadastro/Dockerfile
@@ -15,4 +15,16 @@ COPY ./pipelines/capture__jae_auxiliar/ ./pipelines/capture__jae_auxiliar/
 COPY ./pipelines/treatment__operadora_cnpj/ ./pipelines/treatment__operadora_cnpj/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__cadastro_veiculo/Dockerfile
+++ b/pipelines/treatment__cadastro_veiculo/Dockerfile
@@ -14,4 +14,16 @@ COPY ./pipelines/capture__veiculo_fiscalizacao_lacre ./pipelines/capture__veicul
 
 COPY ./pipelines/common/ ./pipelines/common/
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__cliente_cpf/Dockerfile
+++ b/pipelines/treatment__cliente_cpf/Dockerfile
@@ -11,4 +11,16 @@ COPY ./pipelines/treatment__cliente_cpf ./pipelines/treatment__cliente_cpf/
 
 COPY ./pipelines/common/ ./pipelines/common/
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__datario/Dockerfile
+++ b/pipelines/treatment__datario/Dockerfile
@@ -11,4 +11,16 @@ COPY ./pipelines/treatment__datario ./pipelines/treatment__datario/
 COPY ./pipelines/common/ ./pipelines/common/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__extrato_cliente_cartao/Dockerfile
+++ b/pipelines/treatment__extrato_cliente_cartao/Dockerfile
@@ -19,4 +19,16 @@ COPY ./pipelines/treatment__cadastro ./pipelines/treatment__cadastro/
 COPY ./pipelines/common/ ./pipelines/common/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__financeiro_bilhetagem/Dockerfile
+++ b/pipelines/treatment__financeiro_bilhetagem/Dockerfile
@@ -19,4 +19,16 @@ COPY ./pipelines/capture__jae_ordem_pagamento/ ./pipelines/capture__jae_ordem_pa
 COPY ./pipelines/common/ ./pipelines/common/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__gps_15_minutos_cittati/Dockerfile
+++ b/pipelines/treatment__gps_15_minutos_cittati/Dockerfile
@@ -15,4 +15,16 @@ COPY ./pipelines/capture__cittati_realocacao ./pipelines/capture__cittati_realoc
 COPY ./pipelines/common/ ./pipelines/common/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__gps_15_minutos_conecta/Dockerfile
+++ b/pipelines/treatment__gps_15_minutos_conecta/Dockerfile
@@ -15,4 +15,16 @@ COPY ./pipelines/capture__conecta_realocacao ./pipelines/capture__conecta_realoc
 COPY ./pipelines/common/ ./pipelines/common/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__gps_15_minutos_sppo/Dockerfile
+++ b/pipelines/treatment__gps_15_minutos_sppo/Dockerfile
@@ -15,4 +15,16 @@ COPY ./pipelines/capture__sppo_realocacao ./pipelines/capture__sppo_realocacao/
 COPY ./pipelines/common/ ./pipelines/common/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__gps_15_minutos_sppo/prefect.yaml
+++ b/pipelines/treatment__gps_15_minutos_sppo/prefect.yaml
@@ -43,6 +43,7 @@ deployments:
     schedules:
       - cron: "*/15 * * * *"
         timezone: "America/Sao_Paulo"
+        active: false
     work_pool:
       name: smtr-pool
       work_queue_name: default

--- a/pipelines/treatment__gps_15_minutos_zirix/Dockerfile
+++ b/pipelines/treatment__gps_15_minutos_zirix/Dockerfile
@@ -15,4 +15,16 @@ COPY ./pipelines/capture__zirix_realocacao ./pipelines/capture__zirix_realocacao
 COPY ./pipelines/common/ ./pipelines/common/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__gps_cittati/Dockerfile
+++ b/pipelines/treatment__gps_cittati/Dockerfile
@@ -15,4 +15,16 @@ COPY ./pipelines/capture__cittati_realocacao ./pipelines/capture__cittati_realoc
 COPY ./pipelines/common/ ./pipelines/common/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__gps_conecta/Dockerfile
+++ b/pipelines/treatment__gps_conecta/Dockerfile
@@ -15,4 +15,16 @@ COPY ./pipelines/capture__conecta_realocacao ./pipelines/capture__conecta_realoc
 COPY ./pipelines/common/ ./pipelines/common/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__gps_maxtrack/Dockerfile
+++ b/pipelines/treatment__gps_maxtrack/Dockerfile
@@ -12,4 +12,16 @@ COPY ./pipelines/capture__maxtrack_registros ./pipelines/capture__maxtrack_regis
 
 COPY ./pipelines/common/ ./pipelines/common/
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__gps_sonda/Dockerfile
+++ b/pipelines/treatment__gps_sonda/Dockerfile
@@ -13,4 +13,16 @@ COPY ./pipelines/capture__sonda_registros ./pipelines/capture__sonda_registros/
 COPY ./pipelines/common/ ./pipelines/common/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__gps_sppo/Dockerfile
+++ b/pipelines/treatment__gps_sppo/Dockerfile
@@ -15,4 +15,16 @@ COPY ./pipelines/capture__sppo_realocacao ./pipelines/capture__sppo_realocacao/
 COPY ./pipelines/common/ ./pipelines/common/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__gps_sppo/prefect.yaml
+++ b/pipelines/treatment__gps_sppo/prefect.yaml
@@ -43,6 +43,7 @@ deployments:
     schedules:
       - cron: "6 * * * *"
         timezone: "America/Sao_Paulo"
+        active: false
     work_pool:
       name: smtr-pool
       work_queue_name: default

--- a/pipelines/treatment__gps_validador/Dockerfile
+++ b/pipelines/treatment__gps_validador/Dockerfile
@@ -19,4 +19,16 @@ COPY ./pipelines/capture__jae_auxiliar ./pipelines/capture__jae_auxiliar/
 COPY ./pipelines/common/ ./pipelines/common/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__gps_zirix/Dockerfile
+++ b/pipelines/treatment__gps_zirix/Dockerfile
@@ -15,4 +15,16 @@ COPY ./pipelines/capture__zirix_realocacao ./pipelines/capture__zirix_realocacao
 COPY ./pipelines/common/ ./pipelines/common/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__infraestrutura/Dockerfile
+++ b/pipelines/treatment__infraestrutura/Dockerfile
@@ -11,4 +11,16 @@ COPY ./pipelines/treatment__infraestrutura ./pipelines/treatment__infraestrutura
 COPY ./pipelines/common/ ./pipelines/common/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__integracao/Dockerfile
+++ b/pipelines/treatment__integracao/Dockerfile
@@ -23,4 +23,16 @@ COPY ./pipelines/capture__jae_auxiliar/ ./pipelines/capture__jae_auxiliar/
 COPY ./pipelines/common/ ./pipelines/common/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__jae_timestamps_divergentes/Dockerfile
+++ b/pipelines/treatment__jae_timestamps_divergentes/Dockerfile
@@ -62,4 +62,16 @@ COPY ./pipelines/common/ ./pipelines/common/
 
 COPY ./queries ./queries
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__matriz_integracao_smtr/Dockerfile
+++ b/pipelines/treatment__matriz_integracao_smtr/Dockerfile
@@ -11,4 +11,16 @@ COPY ./pipelines/treatment__matriz_integracao_smtr ./pipelines/treatment__matriz
 COPY ./pipelines/common/ ./pipelines/common/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__monitoramento_temperatura/Dockerfile
+++ b/pipelines/treatment__monitoramento_temperatura/Dockerfile
@@ -15,4 +15,16 @@ COPY ./pipelines/capture__veiculo_fiscalizacao_lacre ./pipelines/capture__veicul
 COPY ./pipelines/common/ ./pipelines/common/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__monitoramento_veiculo/Dockerfile
+++ b/pipelines/treatment__monitoramento_veiculo/Dockerfile
@@ -13,4 +13,16 @@ COPY ./pipelines/capture__veiculo_fiscalizacao_lacre ./pipelines/capture__veicul
 COPY ./pipelines/common/ ./pipelines/common/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__operadora_cnpj/Dockerfile
+++ b/pipelines/treatment__operadora_cnpj/Dockerfile
@@ -11,4 +11,16 @@ COPY ./pipelines/treatment__operadora_cnpj ./pipelines/treatment__operadora_cnpj
 COPY ./pipelines/common/ ./pipelines/common/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__pagamento_cct/Dockerfile
+++ b/pipelines/treatment__pagamento_cct/Dockerfile
@@ -13,4 +13,16 @@ COPY ./pipelines/treatment__pagamento_cct ./pipelines/treatment__pagamento_cct/
 COPY ./pipelines/common/ ./pipelines/common/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__passageiro_hora/Dockerfile
+++ b/pipelines/treatment__passageiro_hora/Dockerfile
@@ -11,4 +11,16 @@ COPY ./pipelines/treatment__passageiro_hora ./pipelines/treatment__passageiro_ho
 COPY ./pipelines/common/ ./pipelines/common/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__planejamento_diario/Dockerfile
+++ b/pipelines/treatment__planejamento_diario/Dockerfile
@@ -11,4 +11,16 @@ COPY ./pipelines/treatment__planejamento_diario ./pipelines/treatment__planejame
 COPY ./pipelines/common/ ./pipelines/common/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__riorotativo_auxiliar/Dockerfile
+++ b/pipelines/treatment__riorotativo_auxiliar/Dockerfile
@@ -16,4 +16,16 @@ COPY ./pipelines/capture__jae_riorotativo_auxiliar ./pipelines/capture__jae_rior
 
 COPY ./pipelines/common/ ./pipelines/common/
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__riorotativo_operacao/Dockerfile
+++ b/pipelines/treatment__riorotativo_operacao/Dockerfile
@@ -26,4 +26,16 @@ COPY ./pipelines/common/ ./pipelines/common/
 
 COPY ./queries ./queries
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__sppo_viagens/CHANGELOG.md
+++ b/pipelines/treatment__sppo_viagens/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - treatment__sppo_viagens
 
+## [1.3.0] - 2026-08-27
+
+### Adicionado
+
+- Adiciona a ingestão dos artefatos dbt no OpenMetadata após a materialização e os testes do flow (https://github.com/RJ-SMTR/pipelines_v3/pull/579)
+
 ## [1.2.1] - 2026-08-20
 
 ### Adicionado

--- a/pipelines/treatment__sppo_viagens/Dockerfile
+++ b/pipelines/treatment__sppo_viagens/Dockerfile
@@ -11,4 +11,16 @@ COPY ./pipelines/treatment__sppo_viagens ./pipelines/treatment__sppo_viagens/
 COPY ./pipelines/common/ ./pipelines/common/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__sppo_viagens/flow.py
+++ b/pipelines/treatment__sppo_viagens/flow.py
@@ -16,6 +16,7 @@ from pipelines.common.tasks import (
     setup_environment,
 )
 from pipelines.common.treatment.default_treatment.tasks import (
+    ingest_dbt_artifacts_to_openmetadata,
     install_dbt_packages,
     run_dbt_selector_tests,
     run_dbt_selectors,
@@ -45,6 +46,8 @@ def treatment__sppo_viagens(  # noqa: PLR0913
     skip_source_check: bool = False,
     force_current_day: bool = False,
 ):
+    deployment_name = runtime.deployment.name
+    flow_run_id = runtime.flow_run.id
     env_task = get_run_env(env=env, deployment_name=runtime.deployment.name)
     setup_env = setup_environment(env=env_task)
     sentry_task = initialize_sentry(env=env_task)
@@ -84,6 +87,13 @@ def treatment__sppo_viagens(  # noqa: PLR0913
             mode="post",
             flags=flags,
             wait_for=[run_dbt],
+        )
+
+        ingest_dbt_artifacts_to_openmetadata(
+            env=env_task,
+            deployment_name=deployment_name,
+            flow_run_id=flow_run_id,
+            wait_for=[post_tests],
         )
 
         post_tests_notify = task_dbt_selector_test_notify_discord.map(

--- a/pipelines/treatment__sppo_viagens/prefect.yaml
+++ b/pipelines/treatment__sppo_viagens/prefect.yaml
@@ -42,14 +42,14 @@ deployments:
       # Modo normal
       - cron: "0 5 * * *"
         timezone: "America/Sao_Paulo"
-        active: true
+        active: false
       - cron: "0 14 * * *"
         timezone: "America/Sao_Paulo"
         active: false
       # Modo acompanhamento D0 (a cada 3h, dia atual)
       - cron: "59 2-23/3 * * *"
         timezone: "America/Sao_Paulo"
-        active: true
+        active: false
         parameters:
           force_current_day: true
     work_pool:

--- a/pipelines/treatment__subsidio_sppo_apuracao/Dockerfile
+++ b/pipelines/treatment__subsidio_sppo_apuracao/Dockerfile
@@ -25,4 +25,16 @@ COPY ./pipelines/capture__jae_transacao_riocard ./pipelines/capture__jae_transac
 COPY ./pipelines/common/ ./pipelines/common/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__transacao/Dockerfile
+++ b/pipelines/treatment__transacao/Dockerfile
@@ -29,4 +29,16 @@ COPY ./pipelines/treatment__transacao ./pipelines/treatment__transacao/
 COPY ./pipelines/common/ ./pipelines/common/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__transacao_erro/Dockerfile
+++ b/pipelines/treatment__transacao_erro/Dockerfile
@@ -19,4 +19,16 @@ COPY ./pipelines/capture__jae_auxiliar ./pipelines/capture__jae_auxiliar/
 COPY ./pipelines/capture__jae_transacao_erro ./pipelines/capture__jae_transacao_erro/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__transacao_ordem/Dockerfile
+++ b/pipelines/treatment__transacao_ordem/Dockerfile
@@ -23,4 +23,16 @@ COPY ./pipelines/capture__jae_ordem_pagamento/ ./pipelines/capture__jae_ordem_pa
 COPY ./pipelines/common/ ./pipelines/common/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__transacao_valor_ordem/Dockerfile
+++ b/pipelines/treatment__transacao_valor_ordem/Dockerfile
@@ -35,4 +35,16 @@ COPY ./pipelines/treatment__transacao_valor_ordem ./pipelines/treatment__transac
 COPY ./pipelines/common/ ./pipelines/common/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__transito_autuacao/Dockerfile
+++ b/pipelines/treatment__transito_autuacao/Dockerfile
@@ -11,4 +11,16 @@ COPY ./pipelines/treatment__transito_autuacao ./pipelines/treatment__transito_au
 COPY ./pipelines/common/ ./pipelines/common/
 COPY ./pipelines/capture__serpro_autuacao/ ./pipelines/capture__serpro_autuacao/
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__validacao_dados_jae/Dockerfile
+++ b/pipelines/treatment__validacao_dados_jae/Dockerfile
@@ -31,4 +31,16 @@ COPY ./pipelines/treatment__validacao_dados_jae ./pipelines/treatment__validacao
 COPY ./pipelines/common/ ./pipelines/common/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__veiculo_dia/Dockerfile
+++ b/pipelines/treatment__veiculo_dia/Dockerfile
@@ -18,4 +18,16 @@ COPY ./pipelines/capture__veiculo_fiscalizacao_lacre ./pipelines/capture__veicul
 COPY ./pipelines/common/ ./pipelines/common/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__viagem_inferida/Dockerfile
+++ b/pipelines/treatment__viagem_inferida/Dockerfile
@@ -25,4 +25,16 @@ COPY ./pipelines/capture__zirix_realocacao ./pipelines/capture__zirix_realocacao
 COPY ./pipelines/common/ ./pipelines/common/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__viagem_informada/Dockerfile
+++ b/pipelines/treatment__viagem_informada/Dockerfile
@@ -15,4 +15,16 @@ COPY ./pipelines/capture__rioonibus_viagem_informada ./pipelines/capture__riooni
 COPY ./pipelines/common/ ./pipelines/common/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/pipelines/treatment__viagem_validacao/Dockerfile
+++ b/pipelines/treatment__viagem_validacao/Dockerfile
@@ -35,4 +35,16 @@ COPY ./pipelines/capture__zirix_realocacao ./pipelines/capture__zirix_realocacao
 COPY ./pipelines/common/ ./pipelines/common/
 
 
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
+
 RUN uv sync --all-packages

--- a/templates/{{ cookiecutter.flow_type }}__{{ cookiecutter.pipeline }}/Dockerfile
+++ b/templates/{{ cookiecutter.flow_type }}__{{ cookiecutter.pipeline }}/Dockerfile
@@ -11,7 +11,17 @@ COPY ./pipelines/{{ cookiecutter.flow_type }}__{{ cookiecutter.pipeline }} ./pip
 COPY ./pipelines/common/ ./pipelines/common/
 
 {% if cookiecutter.flow_type == "treatment" -%}
-COPY ./queries ./queries
+RUN UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv python install 3.11 \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/openmetadata-python uv venv \
+    --python 3.11 /opt/openmetadata \
+    && UV_CACHE_DIR=/tmp/openmetadata-uv-cache uv --no-config pip install --no-cache \
+    --python /opt/openmetadata/bin/python \
+    "openmetadata-ingestion[dbt]==1.13.3.0" \
+    && PYTHONHOME=/usr/local PYTHONPATH=/usr/local/lib/python3.13 \
+    /opt/openmetadata/bin/python -I /opt/openmetadata/bin/metadata --version \
+    && rm -rf /tmp/openmetadata-uv-cache
 
 {%- endif %}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Novos Recursos**
  * Artefatos de execuções dbt passam a ser ingeridos automaticamente no OpenMetadata após testes e validações bem-sucedidos.
  * A integração com o OpenMetadata fica ativada por padrão nos fluxos compatíveis.
  * O suporte à ingestão foi ampliado para diversos pipelines de captura, tratamento, integração e controle de qualidade.

* **Alterações**
  * Agendamentos automáticos de alguns fluxos de GPS e viagens foram desativados, impedindo novas execuções por cron até reativação.
  * Imagens de execução passaram a incluir o suporte necessário à ingestão de artefatos dbt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->