### PR TITLE
Adiciona metadados de domínio ao modelo de planejamento operacional

### DIFF
--- a/queries/dbt_project.yml
+++ b/queries/dbt_project.yml
@@ -420,6 +420,9 @@ models:
       +materialized: incremental
       +incremental_strategy: insert_overwrite
       +schema: gtfs
+      +meta:
+        openmetadata:
+          domain: "planejamento.planejamento_operacional"
       deprecated:
         +materialized: view
         +schema: dashboard_subsidio_van


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentação**
  * Adicionados metadados ao modelo `gtfs`, vinculando-o ao domínio de planejamento operacional no catálogo de dados.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->