### PR TITLE
Altera pré-teste subsidio

### DIFF
--- a/pipelines/treatment__subsidio_sppo_apuracao/CHANGELOG.md
+++ b/pipelines/treatment__subsidio_sppo_apuracao/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Adiciona ao pós-teste o teste `dbt_utils__expression_is_true__irk_tarifa_publica__valor_km_tipo_viagem`. (https://github.com/RJ-SMTR/pipelines_v3/pull/582)
 
 ### Removido
-- Remove os testes de GPS legado (`sppo_registros`, `sppo_realocacao`, `check_gps_treatment__gps_sppo`, `sppo_veiculo_dia`) dos pré-testes V14 e V25. (https://github.com/RJ-SMTR/pipelines_v3/pull/614)
+- Remove os testes de GPS legado (`sppo_registros`, `sppo_realocacao`, `check_gps_treatment__gps_sppo`, `sppo_veiculo_dia`) do pré-teste V25.(https://github.com/RJ-SMTR/pipelines_v3/pull/614)
 
 ## [1.0.5] - 2026-08-28
 

--- a/pipelines/treatment__subsidio_sppo_apuracao/CHANGELOG.md
+++ b/pipelines/treatment__subsidio_sppo_apuracao/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog - treatment__subsidio_sppo_apuracao
 
+## [1.0.6] - 2026-09-01
+
+### Adicionado
+
+- Cria `PRE_TEST_V25_SELECT` e o selector `APURACAO_SUBSIDIO_V25_SELECTOR` para a apuração a partir de `DATA_SUBSIDIO_V25_INICIO`, substituindo `viagem_planejada` e `viagem_completa` por `servico_planejado_faixa_horaria` e `viagem_valida` (Viagens 2.0). (https://github.com/RJ-SMTR/pipelines_v3/pull/614)
+
+### Removido
+- Remove os testes de GPS legado (`sppo_registros`, `sppo_realocacao`, `check_gps_treatment__gps_sppo`, `sppo_veiculo_dia`) dos pré-testes V14 e V25. (https://github.com/RJ-SMTR/pipelines_v3/pull/614)
+
 ## [1.0.5] - 2026-08-28
 
 ### Adicionado

--- a/pipelines/treatment__subsidio_sppo_apuracao/CHANGELOG.md
+++ b/pipelines/treatment__subsidio_sppo_apuracao/CHANGELOG.md
@@ -1,14 +1,21 @@
 # Changelog - treatment__subsidio_sppo_apuracao
 
+## [1.0.7] - 2026-09-02
+
+### Adicionado
+
+- Cria `PRE_TEST_V25_SELECT` e o selector `APURACAO_SUBSIDIO_V25_SELECTOR` para a apuração a partir de `DATA_SUBSIDIO_V25_INICIO`, usando `servico_planejado_faixa_horaria` e `viagem_valida` no lugar de `viagem_planejada` e `viagem_completa` (Viagens 2.0). (https://github.com/RJ-SMTR/pipelines_v3/pull/614)
+- Adiciona no `PRE_CHECKS_LIST` as descrições do teste singular `test_consistencia_servico_planejado_faixa_horaria` e dos testes de `viagem_valida` para a notificação do Discord. (https://github.com/RJ-SMTR/pipelines_v3/pull/614)
+
+### Alterado
+
+- Define `final_datetime` do selector V14 no dia anterior a `DATA_SUBSIDIO_V25_INICIO`. (https://github.com/RJ-SMTR/pipelines_v3/pull/614)
+
 ## [1.0.6] - 2026-09-01
 
 ### Adicionado
 
-- Cria `PRE_TEST_V25_SELECT` e o selector `APURACAO_SUBSIDIO_V25_SELECTOR` para a apuração a partir de `DATA_SUBSIDIO_V25_INICIO`, substituindo `viagem_planejada` e `viagem_completa` por `servico_planejado_faixa_horaria` e `viagem_valida` (Viagens 2.0). (https://github.com/RJ-SMTR/pipelines_v3/pull/614)
 - Adiciona ao pós-teste o teste `dbt_utils__expression_is_true__irk_tarifa_publica__valor_km_tipo_viagem`. (https://github.com/RJ-SMTR/pipelines_v3/pull/582)
-
-### Removido
-- Remove os testes de GPS legado (`sppo_registros`, `sppo_realocacao`, `check_gps_treatment__gps_sppo`, `sppo_veiculo_dia`) do pré-teste V25.(https://github.com/RJ-SMTR/pipelines_v3/pull/614)
 
 ## [1.0.5] - 2026-08-28
 

--- a/pipelines/treatment__subsidio_sppo_apuracao/constants.py
+++ b/pipelines/treatment__subsidio_sppo_apuracao/constants.py
@@ -25,13 +25,11 @@ WEBHOOK_KEY = "subsidio_data_check"
 ADDITIONAL_VARS = {"tipo_teste": "subsidio"}
 
 PRE_TEST_SELECT = (
-    "sppo_registros sppo_realocacao check_gps_treatment__gps_sppo sppo_veiculo_dia"
-    " veiculo_dia tecnologia_servico viagem_planejada transacao transacao_riocard"
+    "veiculo_dia tecnologia_servico viagem_planejada transacao transacao_riocard"
     " gps_validador test_completude__temperatura test_jae_captura_subsidio viagem_completa"
 )
 PRE_TEST_V25_SELECT = (
-    "sppo_registros sppo_realocacao check_gps_treatment__gps_sppo sppo_veiculo_dia"
-    " veiculo_dia tecnologia_servico servico_planejado_faixa_horaria transacao transacao_riocard"
+    "veiculo_dia tecnologia_servico servico_planejado_faixa_horaria transacao transacao_riocard"
     " gps_validador test_completude__temperatura test_jae_captura_subsidio viagem_valida"
 )
 PRE_TEST_EXCLUDE = (
@@ -47,33 +45,6 @@ PRE_CHECKS_LIST = {
             "Captura da Jaé sem timestamps ausentes em `transacao`, `transacao_riocard`"
             " e `gps_validador`"
         )
-    },
-    "sppo_realocacao": {
-        "check_gps_capture__sppo_realocacao": {
-            "description": "Todos os dados de realocação foram capturados"
-        }
-    },
-    "sppo_registros": {
-        "check_gps_capture__sppo_registros": {
-            "description": "Todos os dados de GPS foram capturados"
-        }
-    },
-    "gps_sppo": {
-        "check_gps_treatment__gps_sppo": {
-            "description": "Todos os dados de GPS foram devidamente tratados"
-        },
-        "dbt_utils__unique_combination_of_columns__gps_sppo": {
-            "description": "Todos os registros são únicos"
-        },
-    },
-    "sppo_veiculo_dia": {
-        "not_null": {"description": "Todos os valores da coluna `{column_name}` não nulos"},
-        "dbt_utils__unique_combination_of_columns__data_id_veiculo__sppo_veiculo_dia": {
-            "description": "Todos os registros são únicos"
-        },
-        "dbt_expectations__expect_row_values_to_have_data_for_every_n_datepart__sppo_veiculo_dia": {
-            "description": "Todas as datas possuem dados"
-        },
     },
     "veiculo_dia": {
         "not_null": {"description": "Todos os valores da coluna `{column_name}` não nulos"},
@@ -352,9 +323,6 @@ APURACAO_SUBSIDIO_V14_SELECTOR = DBTSelector(
     post_test=APURACAO_SUBSIDIO_V14_POST_TEST,
 )
 
-# Reusa o selector dbt `apuracao_subsidio_v14`: os modelos de apuração não
-# mudaram no V25 (o corte Viagens 2.0 está nos SQLs). O nome compartilhado
-# mantém o estado no Redis a partir da última materialização V14.
 APURACAO_SUBSIDIO_V25_SELECTOR = DBTSelector(
     name="apuracao_subsidio_v14",
     initial_datetime=DATA_SUBSIDIO_V25_INICIO,

--- a/pipelines/treatment__subsidio_sppo_apuracao/constants.py
+++ b/pipelines/treatment__subsidio_sppo_apuracao/constants.py
@@ -13,6 +13,7 @@ TZ = ZoneInfo(smtr_constants.TIMEZONE)
 
 DATA_SUBSIDIO_V9_INICIO = datetime(2024, 8, 16, 7, 5, 0, tzinfo=TZ)
 DATA_SUBSIDIO_V14_INICIO = datetime(2025, 1, 5, 7, 5, 0, tzinfo=TZ)
+DATA_SUBSIDIO_V25_INICIO = datetime(2026, 8, 1, 7, 5, 0, tzinfo=TZ)
 SUBSIDIO_INITIAL_DATETIME = datetime(2022, 6, 1, 7, 5, 0, tzinfo=TZ)
 
 INCREMENTAL_DELAY_HOURS = 24 * 7  # D-7
@@ -27,6 +28,11 @@ PRE_TEST_SELECT = (
     "sppo_registros sppo_realocacao check_gps_treatment__gps_sppo sppo_veiculo_dia"
     " veiculo_dia tecnologia_servico viagem_planejada transacao transacao_riocard"
     " gps_validador test_completude__temperatura test_jae_captura_subsidio viagem_completa"
+)
+PRE_TEST_V25_SELECT = (
+    "sppo_registros sppo_realocacao check_gps_treatment__gps_sppo sppo_veiculo_dia"
+    " veiculo_dia tecnologia_servico servico_planejado_faixa_horaria transacao transacao_riocard"
+    " gps_validador test_completude__temperatura test_jae_captura_subsidio viagem_valida"
 )
 PRE_TEST_EXCLUDE = (
     "dashboard_subsidio_sppo_v2 teto_viagens__viagens_remuneradas"
@@ -137,6 +143,19 @@ PRE_CHECKS_LIST = {
         "check_partidas_planejadas": {
             "description": "Todas as viagens possuem `partidas_total_planejada` correspondente à OS"
         },
+    },
+    "servico_planejado_faixa_horaria": {
+        "test_consistencia_servico_planejado_faixa_horaria": {
+            "description": (
+                "Os totais de partidas e quilometragem dos serviços planejados "
+                "correspondem aos da Ordem de Serviço para cada "
+                "`feed_start_date`, `tipo_dia` e `tipo_os`"
+            )
+        },
+    },
+    "viagem_valida": {
+        "not_null": {"description": "Todos os valores da coluna `{column_name}` não nulos"},
+        "unique__id_viagem__viagem_valida": {"description": "Todos os registros são únicos"},
     },
     "temperatura_inmet": {
         "test_completude__temperatura": {
@@ -275,6 +294,14 @@ APURACAO_SUBSIDIO_PRE_TEST = DBTTest(
     truncate_date=True,
 )
 
+APURACAO_SUBSIDIO_V25_PRE_TEST = DBTTest(
+    test_select=PRE_TEST_V25_SELECT,
+    exclude=PRE_TEST_EXCLUDE,
+    test_descriptions=PRE_CHECKS_LIST,
+    additional_vars=ADDITIONAL_VARS,
+    truncate_date=True,
+)
+
 APURACAO_SUBSIDIO_V8_POST_TEST = DBTTest(
     test_select=POST_TEST_V8_SELECT,
     test_descriptions=POST_CHECKS_LIST,
@@ -318,9 +345,22 @@ APURACAO_SUBSIDIO_V9_SELECTOR = DBTSelector(
 APURACAO_SUBSIDIO_V14_SELECTOR = DBTSelector(
     name="apuracao_subsidio_v14",
     initial_datetime=DATA_SUBSIDIO_V14_INICIO,
+    final_datetime=DATA_SUBSIDIO_V25_INICIO - timedelta(days=1),
     incremental_delay_hours=INCREMENTAL_DELAY_HOURS,
     flow_folder_name="treatment__subsidio_sppo_apuracao",
     pre_test=APURACAO_SUBSIDIO_PRE_TEST,
+    post_test=APURACAO_SUBSIDIO_V14_POST_TEST,
+)
+
+# Reusa o selector dbt `apuracao_subsidio_v14`: os modelos de apuração não
+# mudaram no V25 (o corte Viagens 2.0 está nos SQLs). O nome compartilhado
+# mantém o estado no Redis a partir da última materialização V14.
+APURACAO_SUBSIDIO_V25_SELECTOR = DBTSelector(
+    name="apuracao_subsidio_v14",
+    initial_datetime=DATA_SUBSIDIO_V25_INICIO,
+    incremental_delay_hours=INCREMENTAL_DELAY_HOURS,
+    flow_folder_name="treatment__subsidio_sppo_apuracao",
+    pre_test=APURACAO_SUBSIDIO_V25_PRE_TEST,
     post_test=APURACAO_SUBSIDIO_V14_POST_TEST,
 )
 

--- a/pipelines/treatment__subsidio_sppo_apuracao/constants.py
+++ b/pipelines/treatment__subsidio_sppo_apuracao/constants.py
@@ -25,7 +25,8 @@ WEBHOOK_KEY = "subsidio_data_check"
 ADDITIONAL_VARS = {"tipo_teste": "subsidio"}
 
 PRE_TEST_SELECT = (
-    "veiculo_dia tecnologia_servico viagem_planejada transacao transacao_riocard"
+    "sppo_registros sppo_realocacao check_gps_treatment__gps_sppo sppo_veiculo_dia"
+    " veiculo_dia tecnologia_servico viagem_planejada transacao transacao_riocard"
     " gps_validador test_completude__temperatura test_jae_captura_subsidio viagem_completa"
 )
 PRE_TEST_V25_SELECT = (
@@ -45,6 +46,33 @@ PRE_CHECKS_LIST = {
             "Captura da Jaé sem timestamps ausentes em `transacao`, `transacao_riocard`"
             " e `gps_validador`"
         )
+    },
+    "sppo_realocacao": {
+        "check_gps_capture__sppo_realocacao": {
+            "description": "Todos os dados de realocação foram capturados"
+        }
+    },
+    "sppo_registros": {
+        "check_gps_capture__sppo_registros": {
+            "description": "Todos os dados de GPS foram capturados"
+        }
+    },
+    "gps_sppo": {
+        "check_gps_treatment__gps_sppo": {
+            "description": "Todos os dados de GPS foram devidamente tratados"
+        },
+        "dbt_utils__unique_combination_of_columns__gps_sppo": {
+            "description": "Todos os registros são únicos"
+        },
+    },
+    "sppo_veiculo_dia": {
+        "not_null": {"description": "Todos os valores da coluna `{column_name}` não nulos"},
+        "dbt_utils__unique_combination_of_columns__data_id_veiculo__sppo_veiculo_dia": {
+            "description": "Todos os registros são únicos"
+        },
+        "dbt_expectations__expect_row_values_to_have_data_for_every_n_datepart__sppo_veiculo_dia": {
+            "description": "Todas as datas possuem dados"
+        },
     },
     "veiculo_dia": {
         "not_null": {"description": "Todos os valores da coluna `{column_name}` não nulos"},

--- a/pipelines/treatment__subsidio_sppo_apuracao/constants.py
+++ b/pipelines/treatment__subsidio_sppo_apuracao/constants.py
@@ -143,14 +143,12 @@ PRE_CHECKS_LIST = {
             "description": "Todas as viagens possuem `partidas_total_planejada` correspondente à OS"
         },
     },
-    "servico_planejado_faixa_horaria": {
-        "test_consistencia_servico_planejado_faixa_horaria": {
-            "description": (
-                "Os totais de partidas e quilometragem dos serviços planejados "
-                "correspondem aos da Ordem de Serviço para cada "
-                "`feed_start_date`, `tipo_dia` e `tipo_os`"
-            )
-        },
+    "test_consistencia_servico_planejado_faixa_horaria": {
+        "description": (
+            "Os totais de partidas e quilometragem dos serviços planejados "
+            "correspondem aos da Ordem de Serviço para cada "
+            "feed_start_date, tipo_dia e tipo_os."
+        )
     },
     "viagem_valida": {
         "not_null": {"description": "Todos os valores da coluna `{column_name}` não nulos"},

--- a/pipelines/treatment__subsidio_sppo_apuracao/flow.py
+++ b/pipelines/treatment__subsidio_sppo_apuracao/flow.py
@@ -3,7 +3,7 @@
 Flow de apuração do subsídio SPPO
 
 Migrado de pipelines_rj_smtr (Prefect 1.4) — `subsidio_sppo_apuracao`.
-Executa selectors V8/V9/monitoramento conforme range de datas, snapshot final
+Executa selectors V8/V9/V14/V25/monitoramento conforme range de datas, snapshot final
 e pré-checagem de captura de dados da Jaé.
 
 Common: 2026-05-22
@@ -37,6 +37,7 @@ def treatment__subsidio_sppo_apuracao(  # noqa: PLR0913
             constants.APURACAO_SUBSIDIO_V8_SELECTOR,
             constants.APURACAO_SUBSIDIO_V9_SELECTOR,
             constants.APURACAO_SUBSIDIO_V14_SELECTOR,
+            constants.APURACAO_SUBSIDIO_V25_SELECTOR,
             constants.MONITORAMENTO_SUBSIDIO_SELECTOR,
         ],
         snapshot_selector=constants.SNAPSHOT_SUBSIDIO_SELECTOR,

--- a/queries/models/monitoramento/CHANGELOG.md
+++ b/queries/models/monitoramento/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - monitoramento
 
+## [2.2.12] - 2026-09-02
+
+### Adicionado
+
+- Adiciona testes `not_null` e `unique` em `viagem_valida` para o pré-teste da apuração V25. (https://github.com/RJ-SMTR/pipelines_v3/pull/614)
+
 ## [2.2.11] - 2026-08-28
 
 ### Adicionado

--- a/queries/models/monitoramento/schema.yml
+++ b/queries/models/monitoramento/schema.yml
@@ -1397,18 +1397,32 @@ models:
       - name: data
         description: "{{ doc('data_viagem') }} [partição]"
         data_type: date
+        tests:
+          - not_null:
+              name: not_null__data__viagem_valida
       - name: id_viagem
         description: "{{ doc('id_viagem') }} [datetime partida em UTC]"
         data_type: string
+        tests:
+          - not_null:
+              name: not_null__id_viagem__viagem_valida
+          - unique:
+              name: unique__id_viagem__viagem_valida
       - name: id_viagem_planejada
         description: "{{ doc('id_viagem_planejada') }}"
         data_type: string
       - name: datetime_partida
         description: "{{ doc('datetime_partida') }}"
         data_type: datetime
+        tests:
+          - not_null:
+              name: not_null__datetime_partida__viagem_valida
       - name: datetime_chegada
         description: "{{ doc('datetime_chegada') }}"
         data_type: datetime
+        tests:
+          - not_null:
+              name: not_null__datetime_chegada__viagem_valida
       - name: modo
         description: "{{ doc('modo') }}"
         data_type: string
@@ -1418,45 +1432,90 @@ models:
       - name: tipo_dia
         description: "{{ doc('tipo_dia') }}"
         data_type: string
+        tests:
+          - not_null:
+              name: not_null__tipo_dia__viagem_valida
       - name: consorcio
         description: "{{ doc('consorcio') }}"
         data_type: string
+        tests:
+          - not_null:
+              name: not_null__consorcio__viagem_valida
       - name: servico
         description: "{{ doc('servico') }}"
         data_type: string
+        tests:
+          - not_null:
+              name: not_null__servico__viagem_valida
       - name: route_id
         description: "{{ doc('route_id') }}"
         data_type: string
+        tests:
+          - not_null:
+              name: not_null__route_id__viagem_valida
       - name: trip_id
         description: "{{ doc('trip_id') }}"
         data_type: string
+        tests:
+          - not_null:
+              name: not_null__trip_id__viagem_valida
       - name: shape_id
         description: "{{ doc('shape_id') }}"
         data_type: string
+        tests:
+          - not_null:
+              name: not_null__shape_id__viagem_valida
       - name: sentido
         description: "{{ doc('sentido') }}"
         data_type: string
+        tests:
+          - not_null:
+              name: not_null__sentido__viagem_valida
       - name: id_veiculo
         description: "{{ doc('id_veiculo') }}"
         data_type: string
+        tests:
+          - not_null:
+              name: not_null__id_veiculo__viagem_valida
       - name: placa
         description: "{{ doc('placa') }}"
         data_type: string
+        tests:
+          - not_null:
+              name: not_null__placa__viagem_valida
+              config:
+                where: "data between date('{date_range_start}') and date('{date_range_end}') and tipo_viagem != 'Não licenciado'"
       - name: ano_fabricacao
         description: "{{ doc('ano_fabricacao') }}"
         data_type: int64
+        tests:
+          - not_null:
+              name: not_null__ano_fabricacao__viagem_valida
+              config:
+                where: "data between date('{date_range_start}') and date('{date_range_end}') and tipo_viagem != 'Não licenciado'"
       - name: tecnologia_apurada
         description: "{{ doc('tecnologia') }}"
         data_type: string
+        tests:
+          - not_null:
+              name: not_null__tecnologia_apurada__viagem_valida
+              config:
+                where: "data between date('{date_range_start}') and date('{date_range_end}') and tipo_viagem != 'Não licenciado'"
       - name: tipo_viagem
         description: "{{ doc('tipo_viagem_status') }}"
         data_type: string
+        tests:
+          - not_null:
+              name: not_null__tipo_viagem__viagem_valida
       - name: feed_start_date
         description: "{{ doc('feed_start_date') }}"
         data_type: date
       - name: distancia_planejada
         description: "{{ doc('distancia_planejada') }}"
         data_type: float64
+        tests:
+          - not_null:
+              name: not_null__distancia_planejada__viagem_valida
       - name: velocidade_media
         description: "{{ doc('velocidade_media_viagem') }}"
         data_type: float64
@@ -1466,6 +1525,9 @@ models:
       - name: versao
         description: "{{ doc('versao') }}"
         data_type: string
+        tests:
+          - not_null:
+              name: not_null__versao__viagem_valida
       - name: id_execucao_dbt
         description: "{{ doc('id_execucao_dbt') }}"
         data_type: string

--- a/queries/models/monitoramento/schema.yml
+++ b/queries/models/monitoramento/schema.yml
@@ -1456,9 +1456,6 @@ models:
       - name: trip_id
         description: "{{ doc('trip_id') }}"
         data_type: string
-        tests:
-          - not_null:
-              name: not_null__trip_id__viagem_valida
       - name: shape_id
         description: "{{ doc('shape_id') }}"
         data_type: string


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Novos Recursos**
  * Adicionado suporte à apuração do subsídio na versão V25, com início em 1º de agosto de 2026.
  * O processamento passa a executar automaticamente a apuração V25.
  * Incluídas validações para serviços planejados, faixas horárias e viagens válidas.

* **Aprimoramentos**
  * Ajustado o período de vigência da versão V14 para encerrar antes do início da V25.
  * Ampliadas as validações de dados de viagens, incluindo verificações de preenchimento e unicidade.
  * Removidas validações relacionadas ao GPS legado e ao preenchimento de `trip_id`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->