### PR TITLE
Remove filtro de operadora para o histórico de clientes da Jaé

### DIFF
--- a/queries/models/cadastro/CHANGELOG.md
+++ b/queries/models/cadastro/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - cadastro
 
+## [1.8.2] - 2026-09-03
+
+### Removido
+
+- Renomeia modelo `aux_operadora_jae_cliente_historico.sql` para `aux_cliente_jae_historico.sql` e move para o `cadastro_interno` ()
+
 ## [1.8.1] - 2026-05-14
 
 ### Removido

--- a/queries/models/cadastro/CHANGELOG.md
+++ b/queries/models/cadastro/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Removido
 
-- Renomeia modelo `aux_operadora_jae_cliente_historico.sql` para `aux_cliente_jae_historico.sql` e move para o `cadastro_interno` ()
+- Renomeia modelo `aux_operadora_jae_cliente_historico.sql` para `aux_cliente_jae_historico.sql` e move para o `cadastro_interno` (https://github.com/RJ-SMTR/pipelines_v3/pull/633)
 
 ## [1.8.1] - 2026-05-14
 

--- a/queries/models/cadastro/staging/aux_operadora_cliente_join_jae_historico.sql
+++ b/queries/models/cadastro/staging/aux_operadora_cliente_join_jae_historico.sql
@@ -21,7 +21,7 @@ with
             o.indicador_operador_ativo_jae
         from {{ ref("aux_operadora_jae_historico") }} o
         left join
-            {{ ref("aux_operadora_jae_cliente_historico") }} c
+            {{ ref("aux_cliente_jae_historico") }} c
             on o.id_cliente = c.id_cliente
             and (
                 (

--- a/queries/models/cadastro_interno/CHANGELOG.md
+++ b/queries/models/cadastro_interno/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### Adicionado
 
-- Renomeia modelo `aux_operadora_jae_cliente_historico.sql` para `aux_cliente_jae_historico.sql` e move para o `cadastro_interno` ()
+- Renomeia modelo `aux_operadora_jae_cliente_historico.sql` para `aux_cliente_jae_historico.sql` e move para o `cadastro_interno` (https://github.com/RJ-SMTR/pipelines_v3/pull/633)
 
 ### Removido
 
-- Remove filtro de `id_cliente` do modelo `aux_cliente_jae_historico.sql` ()
+- Remove filtro de `id_cliente` do modelo `aux_cliente_jae_historico.sql` (https://github.com/RJ-SMTR/pipelines_v3/pull/633)
 
 ## [1.2.1] - 2025-09-17
 

--- a/queries/models/cadastro_interno/CHANGELOG.md
+++ b/queries/models/cadastro_interno/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog - cadastro_interno
 
+## [1.2.2] - 2026-09-03
+
+### Adicionado
+
+- Renomeia modelo `aux_operadora_jae_cliente_historico.sql` para `aux_cliente_jae_historico.sql` e move para o `cadastro_interno` ()
+
+### Removido
+
+- Remove filtro de `id_cliente` do modelo `aux_cliente_jae_historico.sql` ()
+
 ## [1.2.1] - 2025-09-17
 
 ### Alterado

--- a/queries/models/cadastro_interno/staging/aux_cliente_jae_historico.sql
+++ b/queries/models/cadastro_interno/staging/aux_cliente_jae_historico.sql
@@ -46,8 +46,6 @@ with
             nm_cliente as nome
         from {{ ref("staging_cliente") }}
         where
-            cd_cliente
-            in (select cd_cliente from {{ ref("staging_operadora_transporte") }})
             {% if is_incremental() %}
                 and date(data) between date("{{var('date_range_start')}}") and date(
                     "{{var('date_range_end')}}"

--- a/queries/models/cadastro_interno/staging/aux_cliente_jae_historico.sql
+++ b/queries/models/cadastro_interno/staging/aux_cliente_jae_historico.sql
@@ -45,9 +45,9 @@ with
             nr_documento as documento,
             nm_cliente as nome
         from {{ ref("staging_cliente") }}
-        where
-            {% if is_incremental() %}
-                and date(data) between date("{{var('date_range_start')}}") and date(
+        {% if is_incremental() %}
+            where
+                date(data) between date("{{var('date_range_start')}}") and date(
                     "{{var('date_range_end')}}"
                 )
                 and timestamp_captura
@@ -55,7 +55,7 @@ with
                     "{{var('date_range_end')}}"
                 )
 
-            {% endif %}
+        {% endif %}
     ),
     dados_completos as (
         select *, 0 as priority

--- a/queries/models/cadastro_interno/staging/schema.yml
+++ b/queries/models/cadastro_interno/staging/schema.yml
@@ -1,0 +1,14 @@
+version: 2
+
+models:
+  - name: aux_cliente_jae_historico
+    columns:
+      - name: nome
+        policy_tags:
+          - 'projects/rj-smtr/locations/us/taxonomies/388050497607535163/policyTags/3935188996031375059'
+      - name: documento
+        policy_tags:
+          - 'projects/rj-smtr/locations/us/taxonomies/388050497607535163/policyTags/3935188996031375059'
+      - name: id_cliente
+        policy_tags:
+          - 'projects/rj-smtr/locations/us/taxonomies/388050497607535163/policyTags/3935188996031375059'

--- a/queries/selectors.yml
+++ b/queries/selectors.yml
@@ -244,7 +244,7 @@ selectors:
         - method: fqn
           value: aux_operadora_stu
         - method: fqn
-          value: aux_operadora_jae_cliente_historico
+          value: aux_cliente_jae_historico
         - method: fqn
           value: aux_operadora_jae_historico
         - method: fqn


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Novos Recursos**
  * O histórico de clientes JAE agora é processado no dataset `cadastro_interno`.
  * O processamento passou a incluir todos os registros de clientes, mantendo os filtros de período nas execuções incrementais.
  * Foram aplicadas políticas de proteção às colunas sensíveis do modelo.

* **Correções**
  * Referências e seletores foram atualizados para utilizar o novo nome do modelo de histórico de clientes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->