### PR TITLE
Corrigir testes e modelos do planejamento diário

### DIFF
--- a/pipelines/treatment__planejamento_diario/CHANGELOG.md
+++ b/pipelines/treatment__planejamento_diario/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.2.0] - 2026-09-04
+
+### Corrigido
+
+- Restringe os testes pós-materialização aos checks de `servico_planejado_faixa_horaria` e `viagem_planejada_planejamento_dia`, incluindo o `check_km_planejada` para os serviços planejados.
+
 ## [1.1.0] - 2026-08-17
 
 ### Adicionado

--- a/pipelines/treatment__planejamento_diario/CHANGELOG.md
+++ b/pipelines/treatment__planejamento_diario/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Corrigido
 
-- Restringe os testes pós-materialização aos checks de `servico_planejado_faixa_horaria` e `viagem_planejada_planejamento_dia`, incluindo o `check_km_planejada` para os serviços planejados.
+- Restringe os testes pós-materialização aos checks de `servico_planejado_faixa_horaria` e `viagem_planejada_planejamento_dia`, incluindo o `check_km_planejada` para os serviços planejados. ([PR #635](https://github.com/RJ-SMTR/pipelines_v3/pull/635))
 
 ## [1.1.0] - 2026-08-17
 

--- a/pipelines/treatment__planejamento_diario/constants.py
+++ b/pipelines/treatment__planejamento_diario/constants.py
@@ -10,6 +10,12 @@ from pipelines.common import constants as smtr_constants
 from pipelines.common.treatment.default_treatment.utils import DBTSelector, DBTTest
 
 PLANEJAMENTO_DIARIO_CHECKS_LIST = {
+    "check_km_planejada__servico_planejado_faixa_horaria": {
+        "description": (
+            "A quilometragem dos serviços planejados corresponde à da Ordem de Serviço "
+            "para cada data, faixa horária e sentido."
+        )
+    },
     "test_consistencia_servico_planejado_faixa_horaria": {
         "description": (
             "Os totais de partidas e quilometragem dos serviços planejados "
@@ -24,9 +30,17 @@ PLANEJAMENTO_DIARIO_CHECKS_LIST = {
     },
 }
 
+PLANEJAMENTO_DIARIO_TEST_EXCLUDE = (
+    "tag:freshness "
+    "check_km_planejada__sumario_faixa_servico_dia "
+    "check_km_planejada__sumario_faixa_servico_dia_pagamento "
+    "check_km_planejada__viagem_planejada "
+    "tecnologia_servico viagem_informada_monitoramento viagens_remuneradas"
+)
+
 PLANEJAMENTO_DIARIO_TEST = DBTTest(
     test_select="servico_planejado_faixa_horaria viagem_planejada_planejamento_dia",
-    exclude="tag:freshness",
+    exclude=PLANEJAMENTO_DIARIO_TEST_EXCLUDE,
     test_descriptions=PLANEJAMENTO_DIARIO_CHECKS_LIST,
     truncate_date=True,
 )

--- a/pipelines/treatment__planejamento_diario/constants.py
+++ b/pipelines/treatment__planejamento_diario/constants.py
@@ -23,6 +23,12 @@ PLANEJAMENTO_DIARIO_CHECKS_LIST = {
             "feed_start_date, tipo_dia e tipo_os."
         )
     },
+    "test_completude_viagem_planejada_gtfs_sem_os": {
+        "description": (
+            "As viagens sem Ordem de Serviço estão materializadas no planejamento diário "
+            "conforme o calendário operacional."
+        )
+    },
     "viagem_planejada_planejamento_dia": {
         "dbt_utils__unique_combination_of_columns__viagem_planejada_planejamento_dia": {
             "description": "Todos os registros de 'data' e 'id_viagem' são únicos."

--- a/queries/macros/test_check_km_planejada.sql
+++ b/queries/macros/test_check_km_planejada.sql
@@ -105,7 +105,7 @@
             from os
             group by all
         )
-        {% if "viagem_planejada" not in model %}
+        {% if "viagem_planejada" not in model and "servico_planejado_faixa_horaria" not in model %}
             ,
             sumario as (
                 select
@@ -149,12 +149,12 @@
             from os_faixa
             where quilometragem != 0
         ) using (data, servico, faixa_horaria_inicio, sentido)
-    {% if "viagem_planejada" not in model %}
+    {% if "viagem_planejada" not in model and "servico_planejado_faixa_horaria" not in model %}
         full join sumario using (data, servico, faixa_horaria_inicio, sentido)
     {% endif %}
     where
         quilometragem != distancia_total_planejada
-        {% if "viagem_planejada" not in model %}
+        {% if "viagem_planejada" not in model and "servico_planejado_faixa_horaria" not in model %}
             or distancia_total_planejada != km_planejada_faixa
         {% endif %}
 {%- endtest %}

--- a/queries/models/planejamento/extensao_shape.sql
+++ b/queries/models/planejamento/extensao_shape.sql
@@ -1,0 +1,33 @@
+{{
+    config(
+        materialized="incremental",
+        partition_by={
+            "field": "feed_start_date",
+            "data_type": "date",
+            "granularity": "day",
+        },
+        unique_key=["feed_start_date", "shape_id"],
+        incremental_strategy="insert_overwrite",
+    )
+}}
+
+with
+    segmentos as (
+        select
+            feed_start_date,
+            shape_id,
+            cast(comprimento_segmento as numeric) as comprimento_segmento
+        from {{ ref("aux_segmento_shape") }}
+        {% if is_incremental() %}
+            where feed_start_date = date('{{ var("data_versao_gtfs") }}')
+        {% endif %}
+    )
+select
+    feed_start_date,
+    shape_id,
+    sum(comprimento_segmento) / 1000 as extensao,
+    current_datetime("America/Sao_Paulo") as datetime_ultima_atualizacao,
+    '{{ var("version") }}' as versao,
+    '{{ invocation_id }}' as id_execucao_dbt
+from segmentos
+group by 1, 2

--- a/queries/models/planejamento/schema.yml
+++ b/queries/models/planejamento/schema.yml
@@ -495,7 +495,15 @@ models:
         description: "Menor tipo de tecnologia permitida para o veículo"
         data_type: string
   - name: servico_planejado_faixa_horaria
-    description: "Serviços planejados por data, faixa horária e sentido com informações de viagens"
+    description: >-
+      Uma linha por serviço, sentido e faixa horária em cada data, feed_start_date,
+      tipo_dia e tipo_os, com as viagens planejadas agregadas em trip_info. Use
+      (data, feed_start_date, servico, sentido) como chave de join com
+      viagem_planejada_planejamento_dia, associando datetime_partida à faixa
+      entre faixa_horaria_inicio e faixa_horaria_fim. A fonte de verdade das
+      viagens é viagem_planejada_planejamento_dia, e os dados da Ordem de Serviço
+      vêm de aux_os_sppo_faixa_horaria_sentido_dia. É um modelo incremental
+      particionado por data e não mantém histórico versionado.
     tests:
       - check_km_planejada:
           name: check_km_planejada__servico_planejado_faixa_horaria

--- a/queries/models/planejamento/schema.yml
+++ b/queries/models/planejamento/schema.yml
@@ -496,6 +496,9 @@ models:
         data_type: string
   - name: servico_planejado_faixa_horaria
     description: "Serviços planejados por data, faixa horária e sentido com informações de viagens"
+    tests:
+      - check_km_planejada:
+          name: check_km_planejada__servico_planejado_faixa_horaria
     columns:
       - name: data
         description: "Data [partição]"

--- a/queries/models/planejamento/schema.yml
+++ b/queries/models/planejamento/schema.yml
@@ -155,6 +155,27 @@ models:
       - name: end_pt
         description: Último ponto do shape
         data_type: geography
+  - name: extensao_shape
+    description: Uma linha por shape e feed GTFS, com a extensão do shape calculada pela soma do comprimento dos segmentos.
+    columns:
+      - name: feed_start_date
+        description: "{{ doc('feed_start_date') }}"
+        data_type: date
+      - name: shape_id
+        description: "{{ doc('shape_id') }}"
+        data_type: string
+      - name: extensao
+        description: "{{ doc('extensao') }}"
+        data_type: numeric
+      - name: datetime_ultima_atualizacao
+        description: "{{ doc('datetime_ultima_atualizacao') }}"
+        data_type: datetime
+      - name: versao
+        description: "{{ doc('versao') }}"
+        data_type: string
+      - name: id_execucao_dbt
+        description: "{{ doc('id_execucao_dbt') }}"
+        data_type: string
   - name: viagem_planejada_planejamento
     description: Quadro horário de viagens planejadas por tipo de dia, com base no GTFS
     tests:

--- a/queries/models/planejamento/servico_planejado_faixa_horaria.sql
+++ b/queries/models/planejamento/servico_planejado_faixa_horaria.sql
@@ -14,6 +14,23 @@
         and date('{{ var("date_range_end") }}')
 {% endset %}
 
+{% set intervalos = [
+    {"inicio": 0, "fim": 1},
+    {"inicio": 1, "fim": 2},
+    {"inicio": 2, "fim": 3},
+    {"inicio": 3, "fim": 4},
+    {"inicio": 4, "fim": 5},
+    {"inicio": 5, "fim": 6},
+    {"inicio": 6, "fim": 9},
+    {"inicio": 9, "fim": 12},
+    {"inicio": 12, "fim": 15},
+    {"inicio": 15, "fim": 18},
+    {"inicio": 18, "fim": 21},
+    {"inicio": 21, "fim": 22},
+    {"inicio": 22, "fim": 23},
+    {"inicio": 23, "fim": 24},
+] %}
+
 {% set calendario = ref("calendario") %}
 {# {% set calendario = "rj-smtr.planejamento.calendario" %} #}
 {% if execute %}
@@ -37,6 +54,39 @@ with
         from {{ ref("aux_os_sppo_faixa_horaria_sentido_dia") }}
         where {{ incremental_filter }} and {{ feed_filter }}
     ),
+    faixas_horarias_gtfs as (
+        select *
+        from
+            unnest(
+                [
+                    {% for intervalo in intervalos %}
+                        struct(
+                            {{ intervalo.inicio }} as hora_inicio,
+                            {{ intervalo.fim }} as hora_fim
+                        )
+                        {% if not loop.last %},{% endif %}
+                    {% endfor %}
+                ]
+            )
+    ),
+    viagens_planejadas_com_faixa as (
+        select
+            v.*,
+            datetime(v.data)
+            + make_interval(hour => f.hora_inicio) as faixa_horaria_inicio_gtfs,
+            datetime(v.data)
+            + make_interval(hour => f.hora_fim)
+            - interval 1 second as faixa_horaria_fim_gtfs
+        from {{ ref("viagem_planejada_planejamento_dia") }} v
+        left join
+            faixas_horarias_gtfs f
+            on v.datetime_partida
+            >= datetime(v.data) + make_interval(hour => f.hora_inicio)
+            and v.datetime_partida
+            < datetime(v.data) + make_interval(hour => f.hora_fim)
+        {# from `rj-smtr.planejamento.viagem_planejada` #}
+        where {{ incremental_filter }}
+    ),
     viagens_planejadas as (
         select
             data,
@@ -54,10 +104,24 @@ with
             shape_id,
             datetime_partida,
             extensao,
-            trajetos_alternativos
-        from {{ ref("viagem_planejada_planejamento_dia") }}
-        {# from `rj-smtr.planejamento.viagem_planejada` #}
-        where {{ incremental_filter }}
+            trajetos_alternativos,
+            faixa_horaria_inicio_gtfs,
+            faixa_horaria_fim_gtfs,
+            count(*) over (win) as partidas_gtfs,
+            sum(extensao) over (win) as quilometragem_gtfs
+        from viagens_planejadas_com_faixa
+        window
+            win as (
+                partition by
+                    data,
+                    feed_start_date,
+                    tipo_dia,
+                    tipo_os,
+                    servico,
+                    sentido,
+                    faixa_horaria_inicio_gtfs,
+                    faixa_horaria_fim_gtfs
+            )
     ),
     viagens_na_faixa as (
         select
@@ -69,10 +133,14 @@ with
             v.consorcio,
             v.sentido,
             v.extensao,
-            o.partidas,
-            o.quilometragem,
-            o.faixa_horaria_inicio,
-            o.faixa_horaria_fim,
+            coalesce(o.partidas, v.partidas_gtfs) as partidas,
+            coalesce(o.quilometragem, v.quilometragem_gtfs) as quilometragem,
+            coalesce(
+                o.faixa_horaria_inicio, v.faixa_horaria_inicio_gtfs
+            ) as faixa_horaria_inicio,
+            coalesce(
+                o.faixa_horaria_fim, v.faixa_horaria_fim_gtfs
+            ) as faixa_horaria_fim,
             v.modo,
             v.sistema,
             v.vista,

--- a/queries/models/planejamento/viagem_planejada_planejamento.sql
+++ b/queries/models/planejamento/viagem_planejada_planejamento.sql
@@ -171,6 +171,13 @@ with
             and
             {{ is_shape_circular("start_pt", "end_pt", "feed_start_date", "shape_id") }}
     ),
+    shapes as (
+        select feed_start_date, shape_id, shape_distance
+        from {{ ref("shapes_geom_gtfs") }}
+        where
+            feed_start_date >= '{{ var("feed_inicial_viagem_planejada") }}'
+            {% if is_incremental() %} and {{ feed_filter }} {% endif %}
+    ),
     /*
     Monta a base da viagem planejada: converte partida_seconds em horário
     HH:MM:SS normalizado com módulo 24, deriva tipo_dia do service_id
@@ -218,7 +225,8 @@ with
     ),
     /*
     Enriquece a base com dados da Ordem de Serviço (tipo_os e extensão),
-    unindo por feed/serviço/sentido. O tipo_dia é resolvido pela
+    unindo por feed/serviço/sentido. Para viagens sem OS, usa a distância do
+    shape do GTFS como extensão. O tipo_dia é resolvido pela
     macro ordem_servico_excecoes_join, que trata o caso padrão (mesmo tipo_dia)
     e as exceções de calendário (Ponto Facultativo, ENEM, Verão, Réveillon
     etc.). O tipo_dia da OS prevalece quando há correspondência.
@@ -228,7 +236,9 @@ with
             v.* except (tipo_dia),
             coalesce(ose.tipo_dia, v.tipo_dia) as tipo_dia,
             ose.tipo_os,
-            ose.extensao
+            case
+                when ose.tipo_os is null then sg.shape_distance / 1000 else ose.extensao
+            end as extensao
         from viagem_planejada_base v
         left join
             ordem_servico_extensao ose
@@ -236,6 +246,7 @@ with
             and ose.servico = v.servico
             and ose.sentido = v.sentido
             and {{ ordem_servico_excecoes_join("ose", "v") }}
+        left join shapes sg using (feed_start_date, shape_id)
     ),
     /*
     Constrói o array de trajetos alternativos (trip, shape, vista, evento e extensão)

--- a/queries/models/planejamento/viagem_planejada_planejamento.sql
+++ b/queries/models/planejamento/viagem_planejada_planejamento.sql
@@ -171,13 +171,6 @@ with
             and
             {{ is_shape_circular("start_pt", "end_pt", "feed_start_date", "shape_id") }}
     ),
-    shapes as (
-        select feed_start_date, shape_id, shape_distance
-        from {{ ref("shapes_geom_gtfs") }}
-        where
-            feed_start_date >= '{{ var("feed_inicial_viagem_planejada") }}'
-            {% if is_incremental() %} and {{ feed_filter }} {% endif %}
-    ),
     /*
     Monta a base da viagem planejada: converte partida_seconds em horário
     HH:MM:SS normalizado com módulo 24, deriva tipo_dia do service_id
@@ -225,8 +218,8 @@ with
     ),
     /*
     Enriquece a base com dados da Ordem de Serviço (tipo_os e extensão),
-    unindo por feed/serviço/sentido. Para viagens sem OS, usa a distância do
-    shape do GTFS como extensão. O tipo_dia é resolvido pela
+    unindo por feed/serviço/sentido. Para viagens sem OS, usa a extensão do
+    shape segmentado do GTFS. O tipo_dia é resolvido pela
     macro ordem_servico_excecoes_join, que trata o caso padrão (mesmo tipo_dia)
     e as exceções de calendário (Ponto Facultativo, ENEM, Verão, Réveillon
     etc.). O tipo_dia da OS prevalece quando há correspondência.
@@ -237,7 +230,7 @@ with
             coalesce(ose.tipo_dia, v.tipo_dia) as tipo_dia,
             ose.tipo_os,
             case
-                when ose.tipo_os is null then sg.shape_distance / 1000 else ose.extensao
+                when ose.tipo_os is null then se.extensao else ose.extensao
             end as extensao
         from viagem_planejada_base v
         left join
@@ -246,7 +239,7 @@ with
             and ose.servico = v.servico
             and ose.sentido = v.sentido
             and {{ ordem_servico_excecoes_join("ose", "v") }}
-        left join shapes sg using (feed_start_date, shape_id)
+        left join {{ ref("extensao_shape") }} se using (feed_start_date, shape_id)
     ),
     /*
     Constrói o array de trajetos alternativos (trip, shape, vista, evento e extensão)

--- a/queries/models/planejamento/viagem_planejada_planejamento_dia.sql
+++ b/queries/models/planejamento/viagem_planejada_planejamento_dia.sql
@@ -135,11 +135,12 @@ with
             and vp.service_id in unnest(c.service_ids)
             and vp.tipo_dia = c.tipo_dia
             and (
-                vp.tipo_os = c.tipo_os
+                vp.tipo_os is null
+                or vp.tipo_os = c.tipo_os
                 or vp.modo != 'Ônibus'
                 or (
                     length(regexp_extract(vp.servico, r"[0-9]+")) = 4
-                    and regexp_extract(servico, r"[0-9]+") like "2%"
+                    and regexp_extract(vp.servico, r"[0-9]+") like "2%"
                 )
             )
         left join

--- a/queries/tests/test_completude_viagem_planejada_gtfs_sem_os.sql
+++ b/queries/tests/test_completude_viagem_planejada_gtfs_sem_os.sql
@@ -1,0 +1,31 @@
+with
+    calendario as (
+        select data, feed_start_date, tipo_dia, service_ids
+        from {{ ref("calendario") }}
+        where
+            data between date('{{ var("date_range_start") }}') and date(
+                '{{ var("date_range_end") }}'
+            )
+    ),
+    viagens_gtfs_sem_os as (
+        select c.data, c.feed_start_date, vp.id_viagem
+        from calendario c
+        join
+            {{ ref("viagem_planejada_planejamento") }} vp
+            on c.feed_start_date = vp.feed_start_date
+            and vp.service_id in unnest(c.service_ids)
+            and vp.tipo_dia = c.tipo_dia
+            and vp.tipo_os is null
+    ),
+    viagens_materializadas as (
+        select data, feed_start_date, id_viagem
+        from {{ ref("viagem_planejada_planejamento_dia") }}
+        where
+            data between date('{{ var("date_range_start") }}') and date(
+                '{{ var("date_range_end") }}'
+            )
+    )
+select e.data, e.feed_start_date, e.id_viagem
+from viagens_gtfs_sem_os e
+left join viagens_materializadas a using (data, feed_start_date, id_viagem)
+where a.id_viagem is null

--- a/queries/tests/test_consistencia_servico_planejado_faixa_horaria.sql
+++ b/queries/tests/test_consistencia_servico_planejado_faixa_horaria.sql
@@ -13,6 +13,7 @@ with
                 '{{ var("date_range_end") }}'
             )
             and modo = 'Ônibus'
+            and tipo_os is not null
         group by all
     ),
     feeds as (select distinct feed_start_date from servico_planejado_faixa_horaria),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Novos recursos**
  - Incluído o cálculo de faixas horárias, partidas e quilometragem planejada com dados GTFS como fallback.
  - Viagens planejadas sem ordem de serviço passaram a ser incluídas e verificadas na materialização.
  - Adicionado o cálculo da extensão dos shapes a partir de seus segmentos.

- **Correções**
  - Ajustada a conferência de quilometragem para serviços por faixa horária.
  - Corrigida a associação de viagens ao calendário quando não há tipo de ordem de serviço.

- **Documentação**
  - Detalhadas as regras e fontes de dados dos serviços planejados por faixa horária.
  - Atualizado o changelog da versão 1.2.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->