### PR TITLE
Usa o planejamento diário na vista do sumário de serviço a partir da V25

### DIFF
--- a/queries/models/monitoramento/staging/aux_viagem_planejada_planejamento_dia_unnested.sql
+++ b/queries/models/monitoramento/staging/aux_viagem_planejada_planejamento_dia_unnested.sql
@@ -12,10 +12,6 @@ with
             shape_id,
             trajetos_alternativos
         from {{ ref("viagem_planejada_planejamento_dia") }}
-        where
-            data between date('{{ var("date_range_start") }}') and date(
-                '{{ var("date_range_end") }}'
-            )
     ),
     trajetos as (
         select data, feed_start_date, servico, vista, route_id, trip_id, shape_id

--- a/queries/models/monitoramento_interno/CHANGELOG.md
+++ b/queries/models/monitoramento_interno/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - monitoramento_interno
 
+## [1.0.7] - 2026-09-03
+
+### Alterado
+
+- Altera `monitoramento_servico_dia_v2` para obter `vista` de `aux_viagem_planejada_planejamento_dia_unnested` a partir de `DATA_SUBSIDIO_V25_INICIO`. Mantém `viagem_planejada` no período anterior. (https://github.com/RJ-SMTR/pipelines_v3/pull/632)
+
 ## [1.0.6] - 2026-08-28
 
 ### Adicionado

--- a/queries/models/monitoramento_interno/CHANGELOG.md
+++ b/queries/models/monitoramento_interno/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Alterado
 
-- Altera `monitoramento_servico_dia_v2` para obter `vista` de `aux_viagem_planejada_planejamento_dia_unnested` a partir de `DATA_SUBSIDIO_V25_INICIO`. Mantém `viagem_planejada` no período anterior. (https://github.com/RJ-SMTR/pipelines_v3/pull/632)
+- Altera `monitoramento_servico_dia_v2` para obter `vista` de `aux_viagem_planejada_planejamento_dia_unnested` a partir de `DATA_SUBSIDIO_V25_INICIO`. Mantém `viagem_planejada` no período anterior. (https://github.com/RJ-SMTR/pipelines_v3/pull/657)
 
 ## [1.0.6] - 2026-08-28
 

--- a/queries/models/monitoramento_interno/staging/monitoramento_servico_dia_v2.sql
+++ b/queries/models/monitoramento_interno/staging/monitoramento_servico_dia_v2.sql
@@ -52,13 +52,20 @@ with
         from sumario_faixa_servico_dia
     ),
     planejada as (
-        select distinct data, consorcio, servico, vista
+        select distinct data, servico, vista
         from {{ ref("viagem_planejada") }}
         -- `rj-smtr.projeto_subsidio_sppo.viagem_planejada`
         where
             data >= date("{{ var('DATA_SUBSIDIO_V9_INICIO') }}")
+            and data < date("{{ var('DATA_SUBSIDIO_V25_INICIO') }}")
             and (id_tipo_trajeto = 0 or id_tipo_trajeto is null)
             and format_time("%T", time(faixa_horaria_inicio)) != "00:00:00"
+
+        union all
+
+        select data, servico, vista
+        from {{ ref("aux_viagem_planejada_planejamento_dia_unnested") }}
+        where data >= date("{{ var('DATA_SUBSIDIO_V25_INICIO') }}")
     ),
     pagamento as (
         select
@@ -73,7 +80,7 @@ with
             valor_a_pagar as valor_subsidio_pago,
             valor_penalidade
         from valores_subsidio as sdp
-        left join planejada as p using (data, servico, consorcio)
+        left join planejada as p using (data, servico)
         where
             data >= date("{{ var('DATA_SUBSIDIO_V9_INICIO') }}")
             and data between date("{{ var('start_date') }}") and date_add(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Alterações**
  - O monitoramento passa a considerar todas as datas disponíveis na referência de viagens planejadas, sem limitar a consulta a um intervalo específico.
  - A origem das informações de vista é ajustada conforme o período: dados anteriores à atualização seguem a regra histórica, enquanto dados posteriores utilizam a nova referência.
  - A associação dos valores de subsídio passa a considerar apenas data e serviço, garantindo maior consistência no resultado.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->