### PR TITLE
[HOTFIX] Corrige tipo_os na viagem_planejada_dia

### DIFF
--- a/queries/models/planejamento/viagem_planejada_planejamento_dia.sql
+++ b/queries/models/planejamento/viagem_planejada_planejamento_dia.sql
@@ -120,7 +120,7 @@ with
             c.data as data_referencia,
             c.tipo_dia,
             c.subtipo_dia,
-            c.tipo_os,
+            if(vp.tipo_os is null, null, c.tipo_os) as tipo_os,
             os.distancia_total_planejada,
             os.feed_start_date is not null as indicador_possui_os,
             os.horario_inicio,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Correções**
  - Ajustado o preenchimento do tipo de ordem de serviço nas viagens planejadas: quando não informado na origem, o valor permanece nulo; caso contrário, utiliza o tipo correspondente.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->