### PR TITLE
[HOTFIX] Adiciona filtro para guardadores com documento nulo

### DIFF
--- a/queries/models/riorotativo/guardador_veiculo_riorotativo_historico.sql
+++ b/queries/models/riorotativo/guardador_veiculo_riorotativo_historico.sql
@@ -17,7 +17,7 @@
     {% set staging_partitions_query %}
         select distinct cast(documento as int64)
         from {{ ref("staging_guardador_veiculo_riorotativo") }}
-        {% if is_incremental() %} where {{ incremental_filter }} {% endif %}
+        where documento is not null {% if is_incremental() %} and {{ incremental_filter }} {% endif %}
     {% endset %}
     {% set cpf_partitions = (
         run_query(staging_partitions_query).columns[0].values()
@@ -65,7 +65,9 @@ with
     credenciados as (
         select data, documento, tipo_documento, numero_identificacao, cnpj
         from {{ ref("staging_guardador_veiculo_riorotativo") }}
-        {% if is_incremental() %} where {{ incremental_filter }} {% endif %}
+        where
+            documento is not null
+            {% if is_incremental() %} and {{ incremental_filter }} {% endif %}
     ),
     bloqueios as (
         {#


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Correções**
  - Consultas de partições e credenciados agora excluem registros sem documento informado.
  - O processamento incremental continua aplicando seu filtro específico junto à validação de documento preenchido.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->