### PR TITLE
[hotfix] Ajusta recaptura do licenciamento e infração

### DIFF
--- a/pipelines/capture__veiculo_infracao/CHANGELOG.md
+++ b/pipelines/capture__veiculo_infracao/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Alterado
 
-- Alterado recapture_days de 1 para 2 (https://github.com/RJ-SMTR/pipelines_v3/pull/)
+- Alterado recapture_days de 1 para 2 (https://github.com/RJ-SMTR/pipelines_v3/pull/667)
 
 ## [1.0.2] - 2026-09-09
 

--- a/pipelines/capture__veiculo_infracao/CHANGELOG.md
+++ b/pipelines/capture__veiculo_infracao/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.0.3] - 2026-09-11
+
+### Alterado
+
+- Alterado recapture_days de 1 para 2 (https://github.com/RJ-SMTR/pipelines_v3/pull/)
+
 ## [1.0.2] - 2026-09-09
 
 ### Alterado

--- a/pipelines/capture__veiculo_infracao/flow.py
+++ b/pipelines/capture__veiculo_infracao/flow.py
@@ -24,7 +24,7 @@ def capture__veiculo_infracao(
     env: Optional[str] = None,
     timestamp: Optional[str] = None,
     recapture: bool = False,
-    recapture_days: int = 1,
+    recapture_days: int = 2,
     recapture_timestamps: Optional[list[str]] = None,
 ):
     create_capture_flows_default_tasks(

--- a/pipelines/capture__veiculo_infracao/prefect.yaml
+++ b/pipelines/capture__veiculo_infracao/prefect.yaml
@@ -45,7 +45,6 @@ deployments:
         timezone: "America/Sao_Paulo"
         parameters:
           recapture: true
-          recapture_days: 1
     work_pool:
       name: smtr-pool
       work_queue_name: default

--- a/pipelines/capture__veiculo_licenciamento/CHANGELOG.md
+++ b/pipelines/capture__veiculo_licenciamento/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.0.3] - 2026-09-11
+
+### Alterado
+
+- Alterado Alterado recapture_days de 1 para 2 (https://github.com/RJ-SMTR/pipelines_v3/pull/)
+
 ## [1.0.2] - 2026-09-09
 
 ### Alterado

--- a/pipelines/capture__veiculo_licenciamento/CHANGELOG.md
+++ b/pipelines/capture__veiculo_licenciamento/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Alterado
 
-- Alterado Alterado recapture_days de 1 para 2 (https://github.com/RJ-SMTR/pipelines_v3/pull/)
+- Alterado Alterado recapture_days de 1 para 2 (https://github.com/RJ-SMTR/pipelines_v3/pull/667)
 
 ## [1.0.2] - 2026-09-09
 

--- a/pipelines/capture__veiculo_licenciamento/flow.py
+++ b/pipelines/capture__veiculo_licenciamento/flow.py
@@ -24,7 +24,7 @@ def capture__veiculo_licenciamento(
     env: Optional[str] = None,
     timestamp: Optional[str] = None,
     recapture: bool = False,
-    recapture_days: int = 1,
+    recapture_days: int = 2,
     recapture_timestamps: Optional[list[str]] = None,
 ):
     create_capture_flows_default_tasks(

--- a/pipelines/capture__veiculo_licenciamento/prefect.yaml
+++ b/pipelines/capture__veiculo_licenciamento/prefect.yaml
@@ -45,7 +45,6 @@ deployments:
         timezone: "America/Sao_Paulo"
         parameters:
           recapture: true
-          recapture_days: 1
     work_pool:
       name: smtr-pool
       work_queue_name: default


### PR DESCRIPTION
#666

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Alterações**
  * A janela padrão para recaptura de dados foi ampliada de 1 para 2 dias em dois fluxos de captura.
  * Os agendamentos de produção passam a utilizar esse novo padrão, mantendo a recaptura habilitada.

* **Documentação**
  * Changelogs atualizados para registrar a alteração na configuração de recaptura.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->